### PR TITLE
Update health and lint API responses

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -22,8 +22,7 @@ paths:
                   version:
                     type: string
                   uptime:
-                    type: string
-                    description: Uptime as ISO 8601 duration
+                    type: integer
   /api/lint:
     post:
       summary: Lint an OpenAPI spec for issues
@@ -73,9 +72,9 @@ paths:
                   summary:
                     type: object
                     properties:
-                      error_count:
+                      errors:
                         type: integer
-                      warning_count:
+                      warnings:
                         type: integer
                       passed:
                         type: boolean


### PR DESCRIPTION
## Summary
- Changed `uptime` field type from integer to ISO 8601 duration string
- Renamed `errors` → `error_count` and `warnings` → `warning_count` in lint summary
- Added optional `format` field to lint request body

## Test plan
- [ ] Verify Delimit Action catches the breaking changes
- [ ] Check that @claude can auto-fix based on governance feedback

@claude review this PR and fix any API governance issues flagged by the Delimit Action.