### PR TITLE
v4.1.22: rename+wrap shim, self-healing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Works across any configuration — from a single model on a budget to an enterpr
 ## Try it in 2 minutes
 
 ```bash
-npx delimit-cli scan     # Instant health grade for your API spec
-npx delimit-cli demo     # See governance in action — no setup needed
-npx delimit-cli setup    # Configure your AI assistants
+npx delimit-cli scan              # Instant health grade for your API spec
+npx delimit-cli demo              # See governance in action — no setup needed
+npx delimit-cli setup && source ~/.bashrc  # Configure AI assistants + activate
 ```
 
 No API keys. No account. No config files.

--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -874,10 +874,19 @@ program
             } catch (e) {}
         }
 
-        // 7. Shims
+        // 7. Shims + wrapped binaries
         const shimsDir = path.join(HOME, '.delimit', 'shims');
         if (fs.existsSync(shimsDir)) {
             changes.push({ target: '~/.delimit/shims/', action: 'Remove CLI shims directory' });
+        }
+        for (const tool of ['claude', 'codex', 'gemini']) {
+            const searchPaths = [`/usr/local/bin/${tool}-real`, `/usr/bin/${tool}-real`, path.join(HOME, '.local', 'bin', `${tool}-real`)];
+            for (const p of searchPaths) {
+                if (fs.existsSync(p)) {
+                    changes.push({ target: p.replace(HOME, '~'), action: `Restore original ${tool} binary` });
+                    break;
+                }
+            }
         }
 
         // 8. Cross-model governance hooks (LED-202)
@@ -990,6 +999,29 @@ program
                     console.log(chalk.green('✓ Removed from Codex TOML config'));
                 }
             } catch (e) {}
+        }
+
+        // Restore wrapped binaries before removing shims
+        for (const tool of ['claude', 'codex', 'gemini']) {
+            const searchPaths = [
+                `/usr/local/bin/${tool}`,
+                `/usr/bin/${tool}`,
+                path.join(HOME, '.local', 'bin', tool),
+            ];
+            try {
+                const npmBin = execSync('npm bin -g 2>/dev/null', { encoding: 'utf-8', timeout: 3000 }).trim();
+                if (npmBin) searchPaths.push(path.join(npmBin, tool));
+            } catch {}
+            for (const p of searchPaths) {
+                const realPath = p + '-real';
+                try {
+                    if (fs.existsSync(realPath)) {
+                        fs.renameSync(realPath, p);
+                        console.log(chalk.green(`✓ Restored original ${tool} binary`));
+                        break;
+                    }
+                } catch {}
+            }
         }
 
         // Remove shims

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -743,12 +743,16 @@ printf "  \${MAGENTA}\${BOLD}[Delimit]\${RESET} \${MAGENTA}═══════
 sleep 0.08
 printf "  \${GREEN}\${BOLD}[Delimit]\${RESET} \${GREEN}✓ Allowed\${RESET}\\n"
 echo ""
-# Find real binary — check common paths then fallback to PATH search (excluding shim dir)
+# Find real binary — check renamed binary first, then common paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# 1. Check for renamed binary (tool-real) next to this shim
+[ -x "$SCRIPT_DIR/${toolName}-real" ] && exec "$SCRIPT_DIR/${toolName}-real" "$@"
+# 2. Check common paths (skip self)
 SELF="$(readlink -f "$0" 2>/dev/null || echo "$0")"
-for c in /usr/bin/${toolName} /usr/local/bin/${toolName} "$HOME/.local/bin/${toolName}" "$(npm bin -g 2>/dev/null)/${toolName}"; do
+for c in /usr/local/bin/${toolName}-real /usr/bin/${toolName}-real "$HOME/.local/bin/${toolName}-real" /usr/bin/${toolName} /usr/local/bin/${toolName} "$HOME/.local/bin/${toolName}" "$(npm bin -g 2>/dev/null)/${toolName}"; do
     [ -x "$c" ] && [ "$(readlink -f "$c" 2>/dev/null)" != "$SELF" ] && exec "$c" "$@"
 done
-# Last resort: search PATH excluding shim directory
+# 3. Last resort: search PATH excluding shim directory
 REAL=$(PATH=$(echo "$PATH" | tr ':' '\\n' | grep -v '.delimit/shims' | tr '\\n' ':') command -v ${toolName} 2>/dev/null)
 [ -x "$REAL" ] && exec "$REAL" "$@"
 echo "[Delimit] ${toolName} not found in PATH" >&2
@@ -767,10 +771,66 @@ exit 127
                 fs.chmodSync(shimPath, '755');
             }
 
+            // Rename+wrap: place shim at the real binary's location
+            // so it works immediately without PATH changes
+            for (const tool of ['claude', 'codex', 'gemini']) {
+                try {
+                    // Find real binary location
+                    let realPath = null;
+                    const searchPaths = [
+                        `/usr/local/bin/${tool}`,
+                        `/usr/bin/${tool}`,
+                        path.join(os.homedir(), '.local', 'bin', tool),
+                    ];
+                    // Also check npm global bin
+                    try {
+                        const npmBin = execSync('npm bin -g 2>/dev/null', { encoding: 'utf-8', timeout: 3000 }).trim();
+                        if (npmBin) searchPaths.push(path.join(npmBin, tool));
+                    } catch {}
+
+                    for (const p of searchPaths) {
+                        try {
+                            if (fs.existsSync(p) && fs.statSync(p).isFile()) {
+                                // Check it's the real binary, not already our shim
+                                const content = fs.readFileSync(p, 'utf-8').substring(0, 200);
+                                if (!content.includes('Delimit Governance Shim')) {
+                                    realPath = p;
+                                    break;
+                                }
+                            }
+                        } catch {}
+                    }
+
+                    if (realPath) {
+                        const dir = path.dirname(realPath);
+                        const realDest = path.join(dir, `${tool}-real`);
+                        // Only rename if not already renamed
+                        if (!fs.existsSync(realDest)) {
+                            fs.renameSync(realPath, realDest);
+                        }
+                        // Place our shim at the original location
+                        const shimContent = fs.readFileSync(path.join(shimsDir, tool), 'utf-8');
+                        // Update shim to also check for tool-real in same directory
+                        const patchedShim = shimContent.replace(
+                            `echo "[Delimit] ${tool} not found in PATH"`,
+                            `# Check for renamed binary next to shim\n` +
+                            `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"\n` +
+                            `[ -x "$SCRIPT_DIR/${tool}-real" ] && exec "$SCRIPT_DIR/${tool}-real" "$@"\n` +
+                            `echo "[Delimit] ${tool} not found in PATH"`
+                        );
+                        fs.writeFileSync(realPath, patchedShim);
+                        fs.chmodSync(realPath, '755');
+                        log(`  ${green('✓')} ${tool}: wrapped at ${dim(realPath)}`);
+                    }
+                } catch {}
+            }
+
             // Add to PATH in shell rc files (create if missing)
             const pathLine = `export PATH="${shimsDir}:$PATH"  # Delimit governance wrapping`;
             let pathWritten = false;
-            for (const rc of ['.bashrc', '.zshrc', '.profile']) {
+            // Write to ALL rc files that exist — SSH login shells source
+            // .bash_profile (not .bashrc), so we need both
+            for (const rc of ['.bashrc', '.bash_profile', '.zshrc', '.zprofile', '.profile']) {
                 const rcPath = path.join(os.homedir(), rc);
                 try {
                     if (fs.existsSync(rcPath)) {
@@ -782,10 +842,13 @@ exit 127
                     }
                 } catch { /* skip unreadable files */ }
             }
-            // If no rc files exist, create .bashrc with the PATH export
+            // If no rc files exist, create both .bashrc AND .bash_profile
+            // (.bash_profile for SSH login shells, .bashrc for interactive)
             if (!pathWritten) {
-                const bashrc = path.join(os.homedir(), '.bashrc');
-                fs.writeFileSync(bashrc, `# Delimit governance wrapping\n${pathLine}\n`);
+                const snippet = `# Delimit governance wrapping\n${pathLine}\n`;
+                for (const rc of ['.bashrc', '.bash_profile']) {
+                    fs.writeFileSync(path.join(os.homedir(), rc), snippet);
+                }
                 pathWritten = true;
             }
             // Also write to /etc/profile.d/ if writable (login shells)
@@ -800,11 +863,19 @@ exit 127
                 await logp(`  ${green('✓')} Governance shims updated`);
             } else {
                 log(`  ${green('✓')} Governance wrapping enabled`);
+            }
+
+            // Check if shims are already in current PATH
+            const currentPath = process.env.PATH || '';
+            if (!currentPath.includes('.delimit/shims')) {
+                // Can't modify parent shell, but try exec $SHELL -l to reload
                 log('');
-                log(`  ${bold('To activate now, run:')}`);
-                log(`  ${green('source ~/.bashrc')}`);
+                log(`  ${yellow('!')} Run this to activate the banner now:`);
+                log(`  ${green(`export PATH="${shimsDir}:$PATH"`)}`);
                 log('');
-                log(`  ${dim('Or restart your terminal. The banner appears before each AI session.')}`);
+                log(`  ${dim('Or just open a new terminal. Future sessions load it automatically.')}`);
+            } else {
+                log(`  ${green('✓')} Shim active in current shell`);
             }
         } else {
             log(`  ${dim('  Skipped. Enable later: delimit shims enable')}`);
@@ -1170,6 +1241,44 @@ exit 127
     log('');
     log(`  ${bold('Keep Building.')}`);
     log('');
+
+    // Show governance banner preview
+    const shimFile = path.join(DELIMIT_HOME, 'shims', 'claude');
+    if (fs.existsSync(shimFile)) {
+        log(dim('  --- Governance Banner Preview ---'));
+        try {
+            // Run the shim with DELIMIT_WRAPPED=true so it exits after banner
+            // We simulate the banner directly instead
+            const toolCount = (() => {
+                try {
+                    const srv = fs.readFileSync(path.join(DELIMIT_HOME, 'server', 'ai', 'server.py'), 'utf-8');
+                    return (srv.match(/@mcp\.tool/g) || []).length + (srv.match(/mcp\.tool\(\)\(/g) || []).length;
+                } catch { return 0; }
+            })();
+            const version = require('../package.json').version;
+            const purple = '\x1b[35m', magenta = '\x1b[91m', orange = '\x1b[33m';
+            const bold2 = '\x1b[1m', dim2 = '\x1b[2m', reset = '\x1b[0m', green2 = '\x1b[32m';
+            console.log('');
+            console.log(`  ${purple}${bold2}    ____  ________    ______  _____________${reset}`);
+            console.log(`  ${purple}${bold2}   / __ \\/ ____/ /   /  _/  |/  /  _/_  __/${reset}`);
+            console.log(`  ${magenta}${bold2}  / / / / __/ / /    / // /|_/ // /  / /   ${reset}`);
+            console.log(`  ${magenta}${bold2} / /_/ / /___/ /____/ // /  / // /  / /    ${reset}`);
+            console.log(`  ${orange}${bold2}/_____/_____/_____/___/_/  /_/___/ /_/     ${reset}`);
+            console.log(`  ${dim2}v${version}${reset}`);
+            console.log('');
+            console.log(`  ${purple}${bold2}[Delimit]${reset} ${dim2}Executing governance check...${reset}`);
+            console.log(`  ${purple}${bold2}[Delimit]${reset} ${orange}Mode: advisory${reset}`);
+            console.log(`  ${purple}${bold2}[Delimit]${reset} ${dim2}MCP server: ${toolCount} tools${reset}`);
+            console.log(`  ${magenta}${bold2}[Delimit]${reset} ${magenta}═══════════════════════════════════════════${reset}`);
+            console.log(`  ${magenta}${bold2}[Delimit]${reset} ${purple}<${magenta}/${orange}>${reset} ${bold2}GOVERNANCE ACTIVE: CLAUDE${reset}`);
+            console.log(`  ${magenta}${bold2}[Delimit]${reset} ${magenta}═══════════════════════════════════════════${reset}`);
+            console.log(`  ${green2}${bold2}[Delimit]${reset} ${green2}✓ Allowed${reset}`);
+            console.log('');
+            log(dim('  This banner appears before each AI session.'));
+            log(dim('  If you don\'t see it, run: source ~/.bashrc'));
+        } catch {}
+        log('');
+    }
 }
 
 // LED-213: Import canonical template from shared module

--- a/lib/cross-model-hooks.js
+++ b/lib/cross-model-hooks.js
@@ -379,6 +379,18 @@ if [ -d "$SESSIONS" ]; then
   [ -n "$LATEST" ] && python3 -c "import json; d=json.load(open('$LATEST')); s=d.get('summary','')[:150]; print(f'Last session: {s}')" 2>/dev/null
 fi
 echo "=== Delimit Ready ==="
+# Self-heal: re-wrap claude binary if an update overwrote our shim
+CLAUDE_BIN=$(PATH=$(echo "$PATH" | tr ':' '\\n' | grep -v '.delimit/shims' | tr '\\n' ':') command -v claude 2>/dev/null)
+if [ -n "$CLAUDE_BIN" ] && [ -f "$CLAUDE_BIN" ]; then
+  if ! head -5 "$CLAUDE_BIN" 2>/dev/null | grep -q "Delimit Governance Shim"; then
+    # Claude binary exists but is not our shim — re-wrap silently
+    SHIM="$DELIMIT_HOME/shims/claude"
+    if [ -f "$SHIM" ]; then
+      DIR=$(dirname "$CLAUDE_BIN")
+      mv "$CLAUDE_BIN" "$DIR/claude-real" 2>/dev/null && cp "$SHIM" "$CLAUDE_BIN" && chmod 755 "$CLAUDE_BIN" && echo "Shim: re-wrapped after update"
+    fi
+  fi
+fi
 `;
         fs.writeFileSync(hookScript, scriptContent);
         fs.chmodSync(hookScript, '755');
@@ -470,7 +482,7 @@ echo "=== Delimit Ready ==="
         if (!existingSpecLint) {
             config.hooks.PostToolUse.push({
                 matcher: 'Edit|Write',
-                if: "filePath matches '**/*openapi*.yaml' or filePath matches '**/*openapi*.yml' or filePath matches '**/*openapi*.json' or filePath matches '**/*swagger*.yaml' or filePath matches '**/*swagger*.yml' or filePath matches '**/*swagger*.json' or filePath matches '**/api/*.yaml' or filePath matches '**/api/*.yml' or filePath matches '**/specs/**'",
+                if: "path_matches('**/openapi*') || path_matches('**/swagger*') || path_matches('**/specs/**')",
                 hooks: [{
                     type: 'command',
                     command: `${npxCmd} lint "$DELIMIT_FILE_PATH"`,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.1.16",
+  "version": "4.1.22",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary
- Governance shim uses rename+wrap: no PATH changes needed, works immediately
- Self-healing SessionStart hook re-wraps after tool updates
- PostToolUse hook syntax fixed (path_matches instead of filePath matches)
- Write to .bash_profile for SSH login shells
- Uninstall restores original binaries

## Test plan
- [x] 106/106 npm tests pass
- [x] Verified on fresh install: shim works without source ~/.bashrc
- [x] Self-heal tested: banner returns after simulated tool update

🤖 Generated with [Claude Code](https://claude.com/claude-code)