### PR TITLE
chore: release 4.1.45 — shim rename-hack fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.1.45] - 2026-04-09
+
+### Fixed
+- **Shim rename-hack removed** — install no longer races with npm reinstalls that clobbered `/usr/bin/claude` back to a symlink, causing `[Delimit] claude not found in PATH` mid-session. Shim now relies purely on `$HOME/.delimit/shims` being first in `PATH` plus a PATH-strip lookup for the real binary. Fixes regressions from the claude-real rename+wrap install mechanism.
+- Shim exit screen parity and CLI lint output parity (LED-078, LED-087).
+
 ## [4.20.0] - 2026-04-20
 
 *The highest state of AI governance.*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.1.44",
+  "version": "4.1.45",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary
- Bumps version to 4.1.45
- Ships the shim rename-hack fix from #42 to npm users
- Fixes "[Delimit] claude not found in PATH" regression mid-session after npm reinstalls

## Release gates
- [x] npm test: 123/123 pass
- [x] npm audit: 0 vulnerabilities
- [x] npm pack dry-run: 550KB, 144 files
- [x] CHANGELOG updated