### PR TITLE
fix: 4.1.48 hotfix — never clobber CLAUDE.md + axios SSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.1.48] - 2026-04-09
+
+### Fixed
+- **CRITICAL: CLAUDE.md clobber on upgrade** — `delimit-cli setup` used a loose heuristic (`# Delimit` + `delimit_ledger_context` or `# Delimit AI Guardrails`) to decide whether to replace a user's entire `CLAUDE.md` with the stock template. Any founder-customized CLAUDE.md that happened to mention `delimit_ledger_context` got clobbered on every upgrade — this included 4.1.47's auto-update flow, which destroyed custom auto-trigger rules, paying-customer protection blocks, and incident-derived escalation rules. The clobber path is removed entirely. `upsertDelimitSection` now either upserts between `<!-- delimit:start -->` / `<!-- delimit:end -->` markers (preserving user content above and below), or — if no markers exist — appends the managed section at the bottom, preserving all existing user content verbatim.
+- Same fix applied to `GEMINI.md` in `lib/cross-model-hooks.js` (previously did a whole-file overwrite if it did not contain the detection phrase).
+- Detection marker changed from the prose phrase `Consensus 123` to the stable structural marker `<!-- delimit:start`, so future template copy changes never break preservation logic.
+
+### Security
+- **axios** bumped from `1.13.6` → `1.15.0` to patch GHSA-3p68-rc4w-qgx5 (NO_PROXY hostname normalization bypass → SSRF, severity: critical).
+
+### Changed
+- Stock `CLAUDE.md` template is now minimal (auto-trigger lifecycle, code/commit/deploy gates, audit trail, links). Founder-only sections (Paying Customers, Strategic/Business Operations, Escalation Rules, venture portfolio context) are no longer shipped in the npm package — they belong in `~/.delimit/CLAUDE.md` or `~/.claude/CLAUDE.md` (never touched by `delimit-cli setup`).
+
+### Tests
+- Added two regression tests in `tests/setup-onboarding.test.js` covering (a) the exact legacy-content-preservation case and (b) the founder-customized CLAUDE.md pattern that triggered the 2026-04-09 incident.
+
 ## [4.1.45] - 2026-04-09
 
 ### Fixed

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -1337,9 +1337,16 @@ function getClaudeMdContent() {
 
 /**
  * Upsert the Delimit section in a file using <!-- delimit:start --> / <!-- delimit:end --> markers.
- * If markers exist, replaces only that region (preserving user content above/below).
- * If no markers exist but old Delimit content is detected, replaces the whole file.
- * If no Delimit content at all, appends the section.
+ *
+ * NEVER clobbers user-authored content outside the markers. The previous behavior
+ * replaced the whole file whenever it detected "old Delimit content" heuristically,
+ * which destroyed founder-customized CLAUDE.md files on every upgrade (v4.1.47 incident).
+ *
+ * Behavior:
+ * - File missing → create with just the managed section.
+ * - File has markers → replace only the region between them (user content above/below preserved).
+ * - File has no markers → append the managed section at the bottom (user content at top preserved).
+ *
  * Returns { action: 'created' | 'updated' | 'unchanged' | 'appended' }
  */
 function upsertDelimitSection(filePath) {
@@ -1354,7 +1361,7 @@ function upsertDelimitSection(filePath) {
 
     const existing = fs.readFileSync(filePath, 'utf-8');
 
-    // Check if markers already exist
+    // Check if managed markers already exist
     const startMarkerRe = /<!-- delimit:start[^>]*-->/;
     const endMarker = '<!-- delimit:end -->';
     const hasStart = startMarkerRe.test(existing);
@@ -1367,25 +1374,16 @@ function upsertDelimitSection(filePath) {
         if (currentVersion === version) {
             return { action: 'unchanged' };
         }
-        // Replace only the delimit section
+        // Replace only the managed region — preserve content above/below
         const before = existing.substring(0, existing.search(startMarkerRe));
         const after = existing.substring(existing.indexOf(endMarker) + endMarker.length);
         fs.writeFileSync(filePath, before + newSection + after);
         return { action: 'updated' };
     }
 
-    // No markers — check for old Delimit content that should be replaced
-    const isOldDelimit = existing.includes('# Delimit AI Guardrails') ||
-        existing.includes('delimit_init') ||
-        existing.includes('persistent memory, verified execution') ||
-        (existing.includes('# Delimit') && existing.includes('delimit_ledger_context'));
-
-    if (isOldDelimit) {
-        fs.writeFileSync(filePath, newSection + '\n');
-        return { action: 'updated' };
-    }
-
-    // File exists with user content but no Delimit section — append
+    // No markers present — append the managed section at the bottom.
+    // User content at the top is preserved verbatim. Markers get added so future
+    // upgrades can update just the managed region.
     const separator = existing.endsWith('\n') ? '\n' : '\n\n';
     fs.writeFileSync(filePath, existing + separator + newSection + '\n');
     return { action: 'appended' };

--- a/lib/cross-model-hooks.js
+++ b/lib/cross-model-hooks.js
@@ -666,21 +666,43 @@ function installGeminiHooks(tool, hookConfig) {
         } catch { config = {}; }
     }
 
-    // LED-213: Use canonical Consensus 123 template (condensed for JSON)
+    // LED-213: canonical governance template (condensed for JSON).
+    // Detect via the stable <!-- delimit:start --> marker, not a prose phrase
+    // that may change between versions.
     const govInstructions = getDelimitSectionCondensed();
+    const DELIMIT_MARKER = '<!-- delimit:start';
 
-    if (!config.customInstructions || !config.customInstructions.includes('Consensus 123')) {
+    if (!config.customInstructions || !config.customInstructions.includes(DELIMIT_MARKER)) {
         config.customInstructions = govInstructions;
         changes.push('customInstructions');
     }
 
     fs.writeFileSync(tool.configPath, JSON.stringify(config, null, 2));
 
-    // LED-213: Write GEMINI.md with canonical Consensus 123 template
+    // GEMINI.md: use the same upsert pattern as CLAUDE.md so user content
+    // outside the managed markers is preserved across delimit-cli upgrades.
     const geminiMd = path.join(geminiDir, 'GEMINI.md');
-    if (!fs.existsSync(geminiMd) || !fs.readFileSync(geminiMd, 'utf-8').includes('Consensus 123')) {
-        fs.writeFileSync(geminiMd, getDelimitSection() + '\n');
+    const managedSection = getDelimitSection();
+    if (!fs.existsSync(geminiMd)) {
+        fs.writeFileSync(geminiMd, managedSection + '\n');
         changes.push('GEMINI.md');
+    } else {
+        const existing = fs.readFileSync(geminiMd, 'utf-8');
+        if (existing.includes(DELIMIT_MARKER) && existing.includes('<!-- delimit:end -->')) {
+            // Replace only the managed region
+            const before = existing.substring(0, existing.indexOf(DELIMIT_MARKER));
+            const after = existing.substring(existing.indexOf('<!-- delimit:end -->') + '<!-- delimit:end -->'.length);
+            const updated = before + managedSection + after;
+            if (updated !== existing) {
+                fs.writeFileSync(geminiMd, updated);
+                changes.push('GEMINI.md');
+            }
+        } else {
+            // Append managed section below existing user content
+            const sep = existing.endsWith('\n') ? '\n' : '\n\n';
+            fs.writeFileSync(geminiMd, existing + sep + managedSection + '\n');
+            changes.push('GEMINI.md');
+        }
     }
 
     return changes;

--- a/lib/delimit-template.js
+++ b/lib/delimit-template.js
@@ -21,85 +21,36 @@ function getDelimitSection() {
 
 Unify all AI coding assistants with persistent context, governance, and multi-model debate.
 
-## Auto-Trigger Rules (Consensus 123)
+## What Delimit does
+- **API governance** — lint, diff, semver classification, migration guides
+- **Persistent context** — memory and ledger survive across sessions and models
+- **Security audit** — dependency scanning, secret detection
+- **Test verification** — confirm tests actually ran, measure coverage
+- **Multi-model deliberation** — consensus from multiple AI models (3 free, then BYOK)
 
-These rules fire automatically. The AI MUST call the specified tools without asking permission.
-The founder reviews and approves via email. The AI's job is to draft, send, and chain — not to ask.
+## Auto-Trigger Rules
+
+These rules fire automatically. Call the listed tools without asking permission.
 
 ### Session Lifecycle
-- **Session start**: call \`delimit_revive\` + \`delimit_ledger_context\` + \`delimit_gov_health\` + \`delimit_inbox_daemon(action="start")\` + \`delimit_notify_routing(action="status")\`
-- **Session end or idle**: call \`delimit_soul_capture\` + \`delimit_session_handoff\` to preserve context for next session
+- **Session start**: call \`delimit_revive\` + \`delimit_ledger_context\` + \`delimit_gov_health\`
+- **Session end or idle**: call \`delimit_soul_capture\` + \`delimit_session_handoff\`
 - If returning user, summarize what's pending. If new project, call \`delimit_scan\`.
 
 ### Code Development (debounced per edit batch)
 - After editing UI/CSS: call \`delimit_design_validate_responsive\`
 - After editing API specs: call \`delimit_lint\` + \`delimit_drift_check\`
-- After editing tests: call \`delimit_test_smoke\`
-- After any significant code change: call \`delimit_test_smoke\` if applicable tests exist
+- After editing tests or significant code: call \`delimit_test_smoke\`
 
 ### Pre-Commit / Pre-Deploy Gates
 - Before \`git commit\`: call \`delimit_repo_diagnose\`
-- Deploy requested: \`delimit_security_audit\` then \`delimit_test_smoke\` then \`delimit_changelog\` then \`delimit_deploy_plan\`
+- Deploy requested: \`delimit_security_audit\` → \`delimit_test_smoke\` → \`delimit_changelog\` → \`delimit_deploy_plan\`
 - Deploy succeeds: \`delimit_deploy_verify\` + \`delimit_evidence_collect\`
 - Verify succeeds: \`delimit_ledger_done\` (related task) + \`delimit_notify\`
 
-### Change Management (update docs with every ship)
-- After shipping a feature: update README if CLI commands or tool count changed
-- After version bump: update version badge, tool count, test count on landing page
-- After npm publish: sync gateway server.py to npm bundle, scrub PII, run security-check.sh
-- After changing pricing/tiers: update pricing page and Lemon Squeezy product
-- Before deploy: call \`delimit_swarm(action="docs_check")\` to verify docs freshness
-- Before submitting a PR to an external repo: call \`delimit_deliberate\` on the diff + PR description (Pro only — if using free tier deliberations and quota is exhausted, skip this gate but log a warning)
-
-### Content / Outreach (all drafts, never auto-post)
-- Social content drafted: ALWAYS call \`delimit_social_post\` or \`delimit_notify\` immediately
-- \`delimit_social_target\` scan completes: call \`delimit_notify\` with target summary
-- Screenshot of social thread shared: auto-draft reply + call \`delimit_notify\`
-- During ANY social interaction: scan for competitive signals, integration opportunities, and strategic items. Add to strategy ledger if significant.
-
-### Strategic / Business Operations
-- Strategic opportunity identified: call \`delimit_ledger_add\` immediately
-- \`delimit_ledger_add\` fires (non-P0): \`delimit_notify\` (batched, 15-min digest)
-- \`delimit_ledger_add\` fires (P0): \`delimit_notify\` (immediate) + \`delimit_agent_dispatch\`
-- Conflicting high-severity signals: call \`delimit_deliberate\` for multi-model consensus
-
-### Monitoring / Sensors
-- GitHub issue state change (closed, merged, labeled): \`delimit_ledger_update\` + \`delimit_notify\` (immediate)
-- GitHub issue new comments: \`delimit_ledger_update\` + \`delimit_notify\` (batched digest)
-- \`delimit_drift_check\` finds drift: \`delimit_ledger_add\` + \`delimit_notify\`
-
-### Approval Loop (Email Control Plane)
-- Approval email detected: execute the approved action based on context
-- Rejection email detected: \`delimit_ledger_update\` (mark rejected)
-
 ### Audit Trail
 - After security audit, test run, or deploy: call \`delimit_evidence_collect\`
-- Any gate failure: \`delimit_evidence_collect\` + \`delimit_ledger_add\` + \`delimit_notify\` (immediate)
-
-### Storm Prevention
-- Edit triggers: debounce to once per assistant turn
-- Non-P0 notifications: batch into 15-minute digests
-- Max 5 immediate notifications per hour (overflow to digest)
-- Per-scan fan-out: max 10 targets per notification
-
-## Memory Rules (CRITICAL)
-
-Routine code changes are auto-captured from git on session exit. You do NOT need to call memory_store for normal work.
-
-ONLY use \`memory_store\` to capture:
-- **Failed approaches** — "tried X, it didn't work because Y" (git only shows what survived, not dead ends)
-- **Architecture decisions** — "chose PostgreSQL over Redis for sessions because Z"
-- **Key context** — customer requirements, API constraints, deployment gotchas
-- **Things that will confuse the next session** — non-obvious setups, workarounds, tech debt
-
-Do NOT store: routine code changes, file lists, commit messages, status updates — these are in git.
-
-## What Delimit does:
-- **API governance** -- lint, diff, semver classification, migration guides
-- **Persistent context** -- memory and ledger survive across sessions and models
-- **Security audit** -- dependency scanning, secret detection
-- **Test verification** -- confirm tests actually ran, measure coverage
-- **Multi-model deliberation** -- consensus from multiple AI models (3 free, then BYOK)
+- Any gate failure: \`delimit_evidence_collect\` + \`delimit_ledger_add\` + \`delimit_notify\`
 
 ## GitHub Action
 Add breaking change detection to any repo:
@@ -109,28 +60,11 @@ Add breaking change detection to any repo:
     spec: api/openapi.yaml
 \`\`\`
 
-## Paying Customers (CRITICAL — Read Before Any Change)
+## Project-specific overrides
 
-Delimit has paying Pro customers. Every code change, MCP tool modification, server update, or API change MUST consider impact on existing users.
+You can add your own rules anywhere **outside** the \`<!-- delimit:start -->\` / \`<!-- delimit:end -->\` markers in this file — \`delimit-cli\` upgrades only touch content between the markers and preserve everything else.
 
-### Customer Protection Rules
-- **Before modifying any MCP tool signature** (params, return schema): check if it would break existing Pro users' workflows
-- **Before renaming/removing CLI commands**: these are documented and users depend on them
-- **Before changing license validation**: customers have active license keys (Lemon Squeezy)
-- **Before modifying server.py tool definitions**: Pro users have the MCP server installed locally at ~/.delimit/server/
-- **Before changing JSONL/JSON storage formats**: memory, ledger, evidence files may exist on customer machines
-- **npm publish is a production deploy**: every publish goes to real users, not just us
-- **Gateway → npm sync**: when syncing server.py to the npm bundle, verify no breaking tool changes
-- **Test with \`delimit doctor\`** before any publish to catch config/setup breaks
-- **Backwards compatibility**: new features must not break existing installations. Add, don't remove.
-
-### What Constitutes a Breaking Change for Users
-- MCP tool parameter renamed or removed
-- CLI command renamed or removed
-- Storage format change (memories.jsonl, ledger, evidence, license.json)
-- Python import path changes in server.py
-- Hook format changes in settings.json
-- Default behavior changes (e.g., changing what \`delimit scan\` does with no args)
+For user-global overrides (rules that apply to every project and every Claude Code session on this machine), put them in \`~/.claude/CLAUDE.md\` or \`~/.delimit/CLAUDE.md\`. Those files are never shipped in the npm package and never overwritten by \`delimit-cli setup\`.
 
 ## Links
 - Docs: https://delimit.ai/docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "delimit-cli",
-  "version": "4.1.47",
+  "version": "4.1.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "delimit-cli",
-      "version": "4.1.47",
+      "version": "4.1.48",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "1.13.6",
+        "axios": "1.15.0",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "express": "^4.18.0",
@@ -134,14 +134,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1166,10 +1166,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.1.47",
+  "version": "4.1.48",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [
@@ -76,7 +76,7 @@
     "url": "https://github.com/delimit-ai/delimit-mcp-server.git"
   },
   "dependencies": {
-    "axios": "1.13.6",
+    "axios": "1.15.0",
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "express": "^4.18.0",

--- a/tests/cross-model-hooks.test.js
+++ b/tests/cross-model-hooks.test.js
@@ -286,7 +286,7 @@ describe('installCodexHooks', () => {
 
         const instructions = fs.readFileSync(tool.instructionsPath, 'utf-8');
         assert.ok(instructions.includes('delimit:hooks-start'));
-        assert.ok(instructions.includes('Consensus 123'), 'Should contain Consensus 123 governance template');
+        assert.ok(instructions.includes('<!-- delimit:start'), 'Should contain Delimit managed section marker');
 
         const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
         assert.ok(config.hooks['pre-commit'].includes('delimit-cli hook pre-commit'));
@@ -338,7 +338,7 @@ describe('installGeminiHooks', () => {
         assert.ok(changes.includes('GEMINI.md'));
 
         const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
-        assert.ok(config.customInstructions.includes('Consensus 123'), 'Should contain Consensus 123 governance template');
+        assert.ok(config.customInstructions.includes('<!-- delimit:start') || config.customInstructions.includes('delimit:start'), 'Should contain Delimit managed section marker');
 
         const geminiMd = fs.readFileSync(path.join(geminiDir, 'GEMINI.md'), 'utf-8');
         assert.ok(geminiMd.includes('# Delimit'), 'GEMINI.md should contain Delimit governance template');

--- a/tests/setup-onboarding.test.js
+++ b/tests/setup-onboarding.test.js
@@ -73,6 +73,8 @@ function getClaudeMdContent() {
     return getDelimitSection() + '\n';
 }
 
+// Mirror of bin/delimit-setup.js upsertDelimitSection. NEVER clobbers user
+// content — always upserts between markers or appends below.
 function upsertDelimitSection(filePath) {
     const newSection = getDelimitSection();
     const version = PKG_VERSION;
@@ -101,16 +103,7 @@ function upsertDelimitSection(filePath) {
         return { action: 'updated' };
     }
 
-    const isOldDelimit = existing.includes('# Delimit AI Guardrails') ||
-        existing.includes('delimit_init') ||
-        existing.includes('persistent memory, verified execution') ||
-        (existing.includes('# Delimit') && existing.includes('delimit_ledger_context'));
-
-    if (isOldDelimit) {
-        fs.writeFileSync(filePath, newSection + '\n');
-        return { action: 'updated' };
-    }
-
+    // No markers — append below existing user content. Never clobber.
     const separator = existing.endsWith('\n') ? '\n' : '\n\n';
     fs.writeFileSync(filePath, existing + separator + newSection + '\n');
     return { action: 'appended' };
@@ -210,14 +203,48 @@ describe('upsertDelimitSection', () => {
         cleanup(f);
     });
 
-    it('replaces old Delimit content without markers', () => {
+    it('preserves old Delimit content by appending markers below (v4.1.47 clobber fix)', () => {
+        // Regression: v4.1.47 and earlier clobbered any CLAUDE.md containing
+        // `# Delimit` + `delimit_ledger_context` or `# Delimit AI Guardrails`
+        // by writing a fresh stock template over the top, destroying the
+        // founder's customizations. The new upsert behavior preserves the
+        // existing content and appends the managed section below.
         const f = tmpFile('old-delimit.md');
-        fs.writeFileSync(f, '# Delimit AI Guardrails\n\nSome old content with delimit_init');
+        const legacy = '# Delimit AI Guardrails\n\nSome old content with delimit_init and delimit_ledger_context\n';
+        fs.writeFileSync(f, legacy);
         const result = upsertDelimitSection(f);
-        assert.strictEqual(result.action, 'updated');
+        assert.strictEqual(result.action, 'appended');
         const content = fs.readFileSync(f, 'utf-8');
-        assert.ok(content.includes('<!-- delimit:start'));
-        assert.ok(!content.includes('# Delimit AI Guardrails'));
+        assert.ok(content.startsWith('# Delimit AI Guardrails'), 'Legacy content MUST be preserved at the top');
+        assert.ok(content.includes('delimit_init'), 'Legacy content MUST still contain delimit_init');
+        assert.ok(content.includes('<!-- delimit:start'), 'Managed section MUST be appended');
+        assert.ok(content.includes('<!-- delimit:end -->'), 'Managed end marker MUST be present');
+        cleanup(f);
+    });
+
+    it('never clobbers a customized CLAUDE.md containing # Delimit and delimit_ledger_context', () => {
+        // Explicit regression for the exact pattern that broke the founder's
+        // /root/CLAUDE.md on 2026-04-09 when shim auto-update ran setup.
+        const f = tmpFile('custom-delimit.md');
+        const founderCustomized = [
+            '# Delimit',
+            '',
+            '## Auto-Trigger Rules (Consensus 123)',
+            '- Session start: call delimit_ledger_context',
+            '',
+            '## Paying Customers (CRITICAL)',
+            '- Never clobber user-customized files',
+            '',
+            '## Escalation Rules',
+            '- Pre-approval of a plan does not extend to unforeseen escalations',
+            '',
+        ].join('\n');
+        fs.writeFileSync(f, founderCustomized);
+        upsertDelimitSection(f);
+        const content = fs.readFileSync(f, 'utf-8');
+        assert.ok(content.includes('## Paying Customers'), 'Founder custom sections MUST survive');
+        assert.ok(content.includes('## Escalation Rules'), 'Founder custom sections MUST survive');
+        assert.ok(content.includes('Pre-approval of a plan'), 'Full founder content MUST survive');
         cleanup(f);
     });
 


### PR DESCRIPTION
## Summary
Critical regression fix for the CLAUDE.md clobber that 4.1.47 shipped to users.

## Why
The shim's background `npm install -g delimit-cli@latest && delimit-cli setup` flow ran on every user's machine when 4.1.47 published. The setup script's `upsertDelimitSection` had a loose heuristic that matched any CLAUDE.md containing `# Delimit` AND `delimit_ledger_context`, then did a full-file overwrite with the stock template — destroying every founder/pro-user customization. The founder's own /root/CLAUDE.md was wiped mid-session by the auto-update.

## Fix
- Remove the `isOldDelimit` clobber path entirely. `upsertDelimitSection` now ONLY upserts between markers, or appends below user content.
- Same fix for GEMINI.md in `lib/cross-model-hooks.js` (was also doing whole-file overwrite if a detection phrase was missing).
- Detection marker changed from prose phrase `Consensus 123` → structural `<!-- delimit:start`.
- Stock template minimized to public-safe content. Founder-only content (Paying Customers, Strategic Ops, Escalation Rules) belongs in `~/.delimit/CLAUDE.md` (never shipped, never overwritten).
- **axios** `1.13.6` → `1.15.0` (GHSA-3p68-rc4w-qgx5 SSRF, severity: critical).

## Tests
- 124/124 passing
- 2 new regression tests in `tests/setup-onboarding.test.js` covering (a) the legacy-content preservation case and (b) the founder-customized pattern that triggered today's incident
- 0 npm-audit vulnerabilities

## Deploy chain
- delimit_security_audit: 0 criticals after axios bump
- delimit_deploy_plan: PLAN-B806769E (planned, ok)
- delimit_deploy_npm: published delimit-cli@4.1.48 to npm registry
- Awaiting verify + evidence after merge

## Critical for users
Every Pro user with a customized CLAUDE.md just had it wiped by 4.1.47's auto-update. This hotfix stops the bleeding for everyone who installs 4.1.48 OR LATER. Users who already lost their content will need to restore from their own backups.