### PR TITLE
ci: fix false positive in publish secrets check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,8 +80,11 @@ jobs:
         working-directory: npm-delimit
         run: |
           npm pack --dry-run 2>&1 | tee /tmp/pack-list.txt
+          # Filter out known false positives (e.g. secrets_broker.py is the
+          # secrets management module, not a secret file).
+          grep -v 'secrets_broker\|secret_detection\|security-check' /tmp/pack-list.txt > /tmp/pack-filtered.txt || true
           for pattern in '.env' 'credentials' 'secret' '.npmrc' '.key' '.pem'; do
-            if grep -i "$pattern" /tmp/pack-list.txt; then
+            if grep -i "$pattern" /tmp/pack-filtered.txt; then
               echo "::error::Potential secret file found in package: $pattern"
               exit 1
             fi


### PR DESCRIPTION
## Summary

The `Check for secrets in package` step in `publish.yml` greps the npm pack file list for patterns like `secret`. This matches `gateway/ai/secrets_broker.py` — the secrets management module, not a secret file. Every CI publish run fails here.

Filters out known false positives (`secrets_broker`, `secret_detection`, `security-check`) before the pattern scan.

Discovered while fixing the `GATEWAY_TOKEN` repo secret — the gateway checkout now passes but publishes still fail on this FP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)