### PR TITLE
fix(shim): 4.1.52 — exit screen reports real session metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [4.1.52] - 2026-04-10
+
+### Fixed (exit shim reporting zeros)
+- **Git commit count always zero** — `git log --after="$SESSION_START"` was passing a raw epoch integer. Git's `--after` needs `@` prefix for epoch time (`--after="@$SESSION_START"`).
+- **Ledger item count always zero** — the awk script matched any line with a `created_at` field but never compared the timestamp against the session start. Now converts `SESSION_START` to ISO format and uses string comparison to count only items created during the session.
+- **Deliberation count always zero** — looked for a `deliberations.jsonl` file that doesn't exist. Deliberations are stored as individual JSON files in `~/.delimit/deliberations/`. Now uses `find -newermt "@$SESSION_START"` to count files created during the session.
+
+### Tests
+- 134/134 npm CLI tests passing (no test changes — shell template fix only).
+
 ## [4.1.51] - 2026-04-09
 
 ### Fixed (gateway loop engine — LED-814)

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -780,24 +780,24 @@ delimit_exit_screen() {
     else
         DURATION="\${ELAPSED}s"
     fi
-    # Count git commits made during session
+    # Count git commits made during session (@ prefix tells git the value is epoch)
     COMMITS=0
     if [ -d "\$SESSION_CWD/.git" ] || git -C "\$SESSION_CWD" rev-parse --git-dir >/dev/null 2>&1; then
-        COMMITS=\$(git -C "\$SESSION_CWD" log --oneline --after="\$SESSION_START" --format="%H" 2>/dev/null | wc -l | tr -d ' ')
+        COMMITS=\$(git -C "\$SESSION_CWD" log --oneline --after="@\$SESSION_START" --format="%H" 2>/dev/null | wc -l | tr -d ' ')
     fi
     # Count ledger items created during session (by timestamp)
     LEDGER_DIR="\$DELIMIT_HOME/ledger"
     LEDGER_ITEMS=0
-    if [ -d "\$LEDGER_DIR" ]; then
+    # Convert epoch SESSION_START to ISO prefix for string comparison
+    SESSION_ISO=\$(date -u -d "@\$SESSION_START" +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -r "\$SESSION_START" +%Y-%m-%dT%H:%M:%S 2>/dev/null || echo "")
+    if [ -d "\$LEDGER_DIR" ] && [ -n "\$SESSION_ISO" ]; then
         for lf in "\$LEDGER_DIR"/*.jsonl; do
             [ -f "\$lf" ] || continue
-            COUNT=\$(awk -v start="\$SESSION_START" '
+            COUNT=\$(awk -v start="\$SESSION_ISO" '
                 BEGIN { n=0 }
                 {
-                    if (match(\$0, /"(created_at|ts)":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}/)) {
-                        n++
-                    } else if (match(\$0, /"(created_at|ts)":([0-9]+)/, arr)) {
-                        if (arr[2]+0 >= start+0) n++
+                    if (match(\$0, /"created_at":"([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})"/, arr)) {
+                        if (arr[1] >= start) n++
                     }
                 }
                 END { print n }
@@ -805,14 +805,11 @@ delimit_exit_screen() {
             LEDGER_ITEMS=\$((LEDGER_ITEMS + COUNT))
         done
     fi
-    # Count deliberations (governance decisions)
+    # Count deliberations created during this session (stored as individual JSON files)
     DELIBERATIONS=0
-    if [ -f "\$DELIMIT_HOME/deliberations.jsonl" ]; then
-        DELIBERATIONS=\$(awk -v start="\$SESSION_START" '
-            BEGIN { n=0 }
-            { if (match(\$0, /"ts":([0-9]+)/, arr)) { if (arr[1]+0 >= start+0) n++ } }
-            END { print n }
-        ' "\$DELIMIT_HOME/deliberations.jsonl" 2>/dev/null || echo "0")
+    DELIB_DIR="\$DELIMIT_HOME/deliberations"
+    if [ -d "\$DELIB_DIR" ]; then
+        DELIBERATIONS=\$(find "\$DELIB_DIR" -maxdepth 1 -name '*.json' -newermt "@\$SESSION_START" 2>/dev/null | wc -l | tr -d ' ')
     fi
     # Determine exit status label
     if [ "\$_EXIT_CODE" -eq 0 ]; then

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.1.51",
+  "version": "4.1.52",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary

Exit shim session summary was reporting 0 for git commits, ledger items, and deliberations.

Three bugs:
1. `git log --after` needs `@` prefix for epoch timestamps
2. Ledger awk script never compared `created_at` against session start
3. Deliberations looked for a JSONL file that doesn't exist (they're individual JSONs)

Shell template fix only, no tool/API/storage changes. 134/134 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)