### PR TITLE
hotfix: v4.3.1 — disclose optional cloud sync + add kill switch (fixes #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,37 @@ The free tier includes API governance, persistent memory, zero-spec extraction, 
 
 ---
 
+## Telemetry & cloud sync
+
+**Short version: none by default.** Nothing leaves your machine unless you explicitly configure it.
+
+**What's always local (source of truth):**
+- `~/.delimit/events/events-YYYY-MM-DD.jsonl` — per-tool-call events (tool name, timestamp, status, model id, session id, trace id). No source code, no prompts, no responses.
+- `~/.delimit/ledger/` — your ledger items, work orders, deliberation transcripts.
+- `~/.delimit/attestations/` — `delimit wrap` output bundles.
+
+**What's OPT-IN (requires you to provide your own Supabase project credentials):**
+- `gateway/ai/supabase_sync.py` mirrors the local event + ledger + work-order + deliberation rows into a Supabase project *you own* so you can view them in `app.delimit.ai`. **It only activates if you set `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` environment variables OR provide `~/.delimit/secrets/supabase.json` with those credentials.** No URL or key is hardcoded in the published package (verify with `grep -r aqbdqxnhzqzswdxifksc $(npm root -g)/delimit-cli/` — zero hits).
+- Data scope when enabled: metadata only (tool names, timestamps, IDs, statuses, venture tags). Never source code, prompts, or model responses.
+
+**Kill switch:**
+Set `DELIMIT_DISABLE_CLOUD_SYNC=1` in your environment to force all sync operations to no-op even if credentials are present. Local files continue to work normally.
+
+```bash
+# Disable cloud sync for a single invocation
+DELIMIT_DISABLE_CLOUD_SYNC=1 delimit lint api/openapi.yaml
+
+# Disable for the shell session
+export DELIMIT_DISABLE_CLOUD_SYNC=1
+```
+
+**Webhook notifications:**
+`gateway/ai/notify.py` emits governance events to a webhook endpoint *only if* you configure `DELIMIT_WEBHOOK_URL` explicitly. Unset by default.
+
+If you spot another code path that could phone home without disclosure, file an issue. This section is maintained as ship-truth, not aspirational.
+
+---
+
 ## Links
 
 - [delimit.ai](https://delimit.ai) -- homepage

--- a/gateway/ai/supabase_sync.py
+++ b/gateway/ai/supabase_sync.py
@@ -1,7 +1,34 @@
-"""Supabase sync -- writes gateway data to cloud for dashboard access.
+"""Supabase sync — OPT-IN cloud mirror of local governance events.
 
-Writes are fire-and-forget (never blocks tool execution).
-If Supabase is unreachable, data stays in local files (always the source of truth).
+This module is OFF BY DEFAULT. It only activates if the user supplies BOTH
+of the following:
+  - SUPABASE_URL environment variable (or `url` key in ~/.delimit/secrets/supabase.json)
+  - SUPABASE_SERVICE_ROLE_KEY env var (or `service_role_key` key in the same file)
+
+When activated, it mirrors locally-written events/ledger/work-order/deliberation
+rows into the user's own Supabase project so they can view them in
+app.delimit.ai. The local files under ~/.delimit/ remain the source of truth;
+this is a read-side convenience, never a write-side requirement.
+
+Data scope (what gets sent when enabled):
+  - events: tool name, timestamp, status, model id, venture tag, session id,
+    risk level, trace id, span id. NO source code. NO prompts. NO responses.
+  - ledger items: id, title, priority, venture, status, description snippet.
+  - work orders: id, metadata fields, status.
+  - deliberations: summary metadata.
+
+KILL SWITCH:
+  Set DELIMIT_DISABLE_CLOUD_SYNC=1 in the environment to disable ALL cloud
+  mirroring even if Supabase credentials are present. The local files continue
+  to work. This is the same-session runtime equivalent of simply not configuring
+  SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY in the first place.
+
+Transport:
+  Writes are fire-and-forget. Tool execution never blocks on Supabase
+  reachability. All sync_* functions swallow exceptions silently; the
+  failure mode is "nothing appears in your dashboard" not "nothing runs."
+
+LED-1056: disclosure added per external issue #56 (delimit-ai/delimit-mcp-server).
 """
 import json
 import os
@@ -17,8 +44,14 @@ _init_attempted = False
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
 SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
 
-# Also check local secrets file
-if not SUPABASE_URL:
+# LED-1056: explicit user kill switch. Overrides any credentials the user
+# might have configured. Setting this env var forces ALL sync_* operations
+# to no-op, making cloud sync unconditionally off for the session.
+_CLOUD_SYNC_DISABLED = os.environ.get("DELIMIT_DISABLE_CLOUD_SYNC", "").strip().lower() in ("1", "true", "yes", "on")
+
+# Also check local secrets file — only if env vars weren't already provided
+# AND the kill switch is not set.
+if not SUPABASE_URL and not _CLOUD_SYNC_DISABLED:
     secrets_file = Path.home() / ".delimit" / "secrets" / "supabase.json"
     if secrets_file.exists():
         try:
@@ -57,8 +90,15 @@ def _normalize_venture(value) -> str:
 
 
 def _get_client():
-    """Lazy-init Supabase client. Returns the SDK client, 'http' for fallback, or None."""
+    """Lazy-init Supabase client. Returns the SDK client, 'http' for fallback, or None.
+
+    Returns None (disabled) if:
+      - DELIMIT_DISABLE_CLOUD_SYNC=1 is set (user kill switch, LED-1056), OR
+      - SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are not configured.
+    """
     global _client, _init_attempted
+    if _CLOUD_SYNC_DISABLED:
+        return None
     if _client is not None:
         return _client
     if _init_attempted:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "delimit-cli",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "delimit-cli",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Closes #56.

## Summary

External issue #56 filed by @Dingisoul-DEV correctly flagged that `gateway/ai/supabase_sync.py` writes event data to Supabase without README disclosure. Investigation + minimal fix.

## Investigation findings

- **Cloud sync is OFF BY DEFAULT.** `_get_client()` returns `None` unless BOTH `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are configured (env vars or `~/.delimit/secrets/supabase.json`). No URL is hardcoded. Verified: `grep -r aqbdqxnhzqzswdxifksc package/` returns zero hits on the v4.3.0 tarball.
- **Data scope is metadata only.** Events sent when enabled: tool name, timestamp, status, model id, session id, trace/span ids. No source code, no prompts, no responses. Confirmed by reading `sync_event()` row shape at `supabase_sync.py:122-160`.
- **Local files remain source of truth.** `~/.delimit/events/*.jsonl` is always written first; cloud sync is a fire-and-forget mirror.

## Changes

- `gateway/ai/supabase_sync.py` — rewrote module docstring to document opt-in behavior, credential sources, data scope, and kill switch. Added `DELIMIT_DISABLE_CLOUD_SYNC=1` env override that forces all sync operations to no-op even if credentials are present.
- `README.md` — new Telemetry & cloud sync section between FAQ and Links.
- `package.json` — 4.3.0 → 4.3.1.

## Behavior impact

- Users without Supabase creds: no change (still zero outbound sync)
- Users who had sync enabled: can now opt out in-session with `DELIMIT_DISABLE_CLOUD_SYNC=1` without removing credentials
- Everyone: disclosure now explicit in README

## Test plan

- [x] `npm test` — 134/134 pass
- [x] Module docstring reflects actual code paths (grep-audited)
- [x] Kill switch: `DELIMIT_DISABLE_CLOUD_SYNC=1 python -c 'from ai.supabase_sync import _get_client; assert _get_client() is None'`
- [x] README grep-truth check on built tarball

## Ledger

LED-1056 (this hotfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)