### PR TITLE
ci: retry verify-published-version with bounded backoff

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,9 +145,20 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         working-directory: npm-delimit
         run: |
-          sleep 10
           PKG_VERSION=$(node -p "require('./package.json').version")
-          npm view "delimit-cli@$PKG_VERSION" version
+          # Registry propagation can take 30-90s after publish. Retry with
+          # bounded backoff instead of racing a fixed 10s sleep (v4.3.4 hit
+          # E404 on the 10s path even though the publish had succeeded).
+          for attempt in 1 2 3 4 5 6; do
+            if npm view "delimit-cli@$PKG_VERSION" version; then
+              echo "verified on attempt $attempt"
+              exit 0
+            fi
+            echo "attempt $attempt: not visible yet, sleeping $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::delimit-cli@$PKG_VERSION not visible in registry after 6 attempts (~5min)"
+          exit 1
 
   release:
     needs: publish


### PR DESCRIPTION
## Summary

- Replaces the fixed 10s sleep in Publish workflow's `Verify published version` step with bounded backoff (6 attempts @ 15/30/45/60/75/90s, ~5min max)
- Fixes the root cause of the v4.3.4 workflow `failure` — registry propagation raced the 10s sleep, E404'd, and since `release` was gated on verify success the auto-Release was skipped

## Why

v4.3.4 shipped cleanly (`npm latest` → `4.3.4`, attestation [att_a05050eb8e13277e](https://delimit.ai/att/att_a05050eb8e13277e)) but the GitHub Release for v4.3.4 had to be created manually because the verify step failed. 10s is empirically not enough for npm propagation; most releases see 30-90s.

## Test plan

- [x] Local syntax check
- [ ] Fires on next tag push (v4.3.5 or later)
- [ ] Verify the release auto-creation step runs once the retry succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)