### PR TITLE
readme: canon-aligned hero + real attestation demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,40 @@
 # `</>` Delimit
 
-Stop re-explaining your codebase every session. Memory, tasks, and governance that persist across Claude Code, Codex, Cursor, and Gemini CLI.
+**The merge gate for AI-written code — with signed, replayable attestation.**
 
+Wrap any AI coding assistant (Claude Code, Codex, Cursor, Gemini CLI) with a governance chain that runs your gates, records what changed, and signs a replayable receipt for every merge.
+
+[![npm](https://img.shields.io/npm/v/delimit-cli)](https://www.npmjs.com/package/delimit-cli)
+[![Tests](https://img.shields.io/badge/tests-165%20passing-brightgreen)](https://github.com/delimit-ai/delimit-mcp-server)
+[![GitHub Action](https://img.shields.io/badge/GitHub%20Action-v1.6.0-blue)](https://github.com/marketplace/actions/delimit-api-governance)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Glama](https://glama.ai/mcp/servers/delimit-ai/delimit/badge)](https://glama.ai/mcp/servers/delimit-ai/delimit)
+
+```console
+$ delimit wrap -- claude "fix the flaky test in tests/api.spec.ts"
+
+✓ repo_diagnose
+✓ security_audit       0 critical · 0 secrets
+✓ test_smoke           165/165
+✓ changed_files        1
+✓ attestation signed   att_a05050eb8e13277e
+                       delimit.attestation.v1 · HMAC-SHA256
+                       replay → https://delimit.ai/att/att_a05050eb8e13277e
+```
+
+Every wrapped run emits a `delimit.attestation.v1` bundle: repo head before/after, changed files, gate results, HMAC-SHA256 signature, and a replay URL. Advisory by default; flip to enforcing when you're ready.
+
+<p align="center">
+  <a href="https://youtu.be/8e_6P7rkFxo">Watch the demo</a> · <a href="https://youtu.be/4O1wY4vWmiY">Multi-model deliberation</a> · <a href="https://delimit.ai">Website</a>
+</p>
 
 ---
 
 ## Think and Build
 
-The universal command for the Delimit Swarm. When you say **"Think and Build"**, your AI agents (Claude, Codex, Gemini, Cursor) automatically deploy a background autonomous build loop that monitors your ledger, deliberates on strategy, and implements code while you focus on the architecture.
+Beyond the merge gate, Delimit orchestrates multi-model deliberation and autonomous builds. `delimit think` dispatches a strategic question to Claude, Codex, Gemini, and Grok; `delimit build` activates a background daemon that executes ledger tasks through the gate chain. `delimit vault` manages local secrets (AES-256).
 
-- **"Think"**: Trigger multi-model deliberation and strategic dispatch.
-- **"Build"**: Activate the background daemon to execute tasks and verify gates.
-- **"Vault"**: Manage local secrets and API keys (AES-256 encrypted).
-
-Works across any configuration — from a single model on a budget to an enterprise swarm of 4+ models.
-
-[![npm](https://img.shields.io/npm/v/delimit-cli)](https://www.npmjs.com/package/delimit-cli)
-[![Tests](https://img.shields.io/badge/tests-134%20passing-brightgreen)](https://github.com/delimit-ai/delimit-mcp-server)
-[![GitHub Action](https://img.shields.io/badge/GitHub%20Action-v1.6.0-blue)](https://github.com/marketplace/actions/delimit-api-governance)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Glama](https://glama.ai/mcp/servers/delimit-ai/delimit/badge)](https://glama.ai/mcp/servers/delimit-ai/delimit)
-
-<p align="center">
-  <img src="docs/demo.gif" alt="Delimit v4.20 — doctor, simulate, status, memory" width="700">
-</p>
-
-<p align="center">
-  <a href="https://youtu.be/8e_6P7rkFxo">Watch the demo</a> · <a href="https://youtu.be/4O1wY4vWmiY">Multi-model deliberation</a> · <a href="https://delimit.ai">Website</a>
-</p>
+Works across any configuration, from a single model on a budget to a full panel.
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the README hero and replaces the stale \`docs/demo.gif\` reference with a fenced \`console\` code block showing a real signed attestation. The old GIF (April 5) looped 8 lines of *"Remembered. (N memories total)"* — it didn't communicate anything about what Delimit does.

## Before / After

**Before (hero):** *"Stop re-explaining your codebase every session. Memory, tasks, and governance that persist across Claude Code, Codex, Cursor, and Gemini CLI."*

**After (hero):** *"The merge gate for AI-written code — with signed, replayable attestation."*

**Before (demo):** embedded \`docs/demo.gif\` showing a repeating "Remembered" counter.

**After (demo):** fenced \`console\` block showing a real \`delimit wrap\` run (attestation \`att_a05050eb8e13277e\`, produced during the v4.3.4 dogfood verify chain).

## Why

- The old hero was memory-forward. Per \`feedback_moat_governance_not_memory.md\`: memory is table stakes, not the moat. Lead with governance, breaking changes, cross-model, audit trail.
- The external promise in the frozen canon block (\`/root/CLAUDE.md\`) is *"The merge gate for AI-written code, with signed, replayable attestation."* Hero copy now matches verbatim.
- Productized output in the canon is *"A signed, replayable attestation for every AI-assisted merge."* The demo code block shows exactly that: schema, signature algorithm, replay URL.
- Vocabulary governance respected: no \`AI OS\`, \`governance platform\`, tool-count hero language, or other banned phrases.

## Also

- Tests badge updated 134 → 165 to match current count.
- \"Think and Build\" section kept but repositioned below the attestation demo; tightened to one paragraph.
- YouTube links preserved. The GIF file (\`docs/demo.gif\`) is left on disk for now — founder can re-record a fresh one and point the README back at it in a follow-up.

## Test plan

- [x] Preview rendering on GitHub
- [x] Canon phrase compliance check (no banned phrases, required canonical phrases present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)