### PR TITLE
feat(setup): build features.json during delimit setup (LED-1084)

### DIFF
--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -273,6 +273,29 @@ async function main() {
         }
     }
 
+    // LED-1084 week 2: build the content-grounding feature whitelist.
+    // Populates ~/.delimit/content/grounding/features.json with every
+    // @mcp.tool() entry + every CLI subcommand we ship. Drafters then
+    // have a concrete list of "things delimit actually does" to check
+    // generated text against. Fail-soft — install continues even if
+    // the build fails for any reason.
+    try {
+        const groundingModule = path.join(DELIMIT_HOME, 'server', 'ai', 'content_grounding', 'features.py');
+        if (fs.existsSync(groundingModule)) {
+            execSync(`"${python}" -m ai.content_grounding.features build`, {
+                stdio: 'pipe',
+                cwd: path.join(DELIMIT_HOME, 'server'),
+                env: { ...process.env, PYTHONPATH: path.join(DELIMIT_HOME, 'server') },
+                timeout: 10000,
+            });
+            await logp(`  ${green('✓')} Grounding whitelist built (~/.delimit/content/grounding/features.json)`);
+        }
+    } catch {
+        // Silent fail — the whitelist is optional; drafters fall back to empty
+        // which makes the gate strict but doesn't break anything. Customers
+        // can rebuild manually later: `python -m ai.content_grounding.features build`.
+    }
+
     // Step 3: Configure Claude Code MCP
     step(3, 'Configuring Claude Code MCP...');
 


### PR DESCRIPTION
LED-1084 week 2 hygiene. Customer-side companion to the gateway-side post-commit hook (PR #42 — merged).

## Problem

After a customer runs `delimit setup`, the Python venv + bundled gateway are ready but `~/.delimit/content/grounding/features.json` was never created. The drafter's grounding gate then runs with an empty whitelist → every feature-claim sentence flags → gate is unusably strict.

## Fix

Run `python -m ai.content_grounding.features build` once during setup, right after Python deps install and before MCP config. Writes the 233-entry (186 MCP tools + 47 CLI commands) whitelist to `~/.delimit/content/grounding/features.json`.

## Fail-soft

- stdio piped (no noise on success)
- 10s timeout
- On failure: silent continue; customer can rebuild manually later
- Never blocks the rest of setup
- Only runs if the bundled `features.py` exists

## Coverage matrix (after both PRs merge)

| Surface | Refresh mechanism |
|---|---|
| Founder local gateway | post-commit hook (gateway PR #42) |
| Customer install | `delimit setup` (this PR) |
| Customer upgrade | re-run `delimit setup` |
| CI-side | TODO — follow-up, not critical |

🤖 Generated with [Claude Code](https://claude.com/claude-code)