### PR TITLE
feat(v4.4.0): delimit_external_pr_check — pre-external-PR duplicate guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [4.4.0] - 2026-04-25
+
+### Added — Pre-external-PR duplicate guard
+
+- **New MCP tool `delimit_external_pr_check(repo, author)`** — pre-flight gate that runs `gh pr list` against a target repo and returns a fail-closed verdict if any matching open PR (or recently-merged PR within 30 days) already exists. Prevents autonomous workflows from drafting duplicate external-repo PRs off stale outreach signals.
+- **`delimit_gov_evaluate(action="external_pr", context={target_repo, author})`** composes the duplicate check + policy evaluation in one call. Verdict `blocked_duplicate` is a hard stop.
+- **CLAUDE.md auto-trigger rule added**: BEFORE drafting any external-repo PR, the duplicate gate must pass.
+- 12 new unit tests covering: open PR, recently-merged PR, old merged PR, closed PR, gh CLI not installed, gh auth failure, missing target_repo. End-to-end test against real `goharbor/harbor` PR #23089 confirms duplicate detection works.
+
+### Documentation
+- readme: replace stale demo links + delete old GIF (#67) (e6059dd3)
+- LED-1089 SECURITY.md — install-time + runtime threat model (#65) (4e03319c)
+- readme: canon-aligned hero + real attestation demo (#63) (9172924a)
+
+### CI/CD
+- retry verify-published-version with bounded backoff (fixes v4.3.4 race) (#62) (f5a768d5)
+
+### Other
+- LED-1084 week 2 hygiene: build features.json during `delimit setup` (#66) (8145456f)
+- sync: gateway LED-1010 design tool fixes (Tailwind awareness, status taxonomy, link-href FP) (#64) (d756e1bb)
+
+### Completed Ledger Items
+- **LED-1094**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1095**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1096**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1097**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1098**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1100**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1102**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1103**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1104**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1105**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1106**: [P1] Build responsive-overflow gate (narrow MVP) — dogfood on delimit.ai
+- **LED-1107**: [P1] Fix 3 responsive overflow bugs caught by LED-1106 gate on first dogfood run
+- **LED-1108**: [P1] Cross-venture task
+- **LED-1109**: [P1] Cross-venture task
+- **LED-1110**: [P1] Cross-venture task
+- **LED-1111**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+- **LED-1113**: [P1] Cross-venture task
+- **LED-1114**: [P1] Consensus reached: Review the full transcript. As orchestrator, provide your own analysis and final
+
+### Stats
+- **Commits**: 6
+- **Files changed**: 6
+- **Insertions**: 708(+) / 130(-)
+- **Since**: v4.3.4
+
 ## [4.2.0] - 2026-04-21
 
 ### Added (gateway sync — LED-987 through LED-1008)

--- a/gateway/ai/backends/governance_bridge.py
+++ b/gateway/ai/backends/governance_bridge.py
@@ -158,9 +158,49 @@ def _not_init_response(tool_name: str, **extra) -> Dict[str, Any]:
 
 
 def evaluate_trigger(action: str, context: Optional[Dict] = None, repo: str = ".") -> Dict[str, Any]:
-    """Evaluate if governance is required for an action."""
+    """Evaluate if governance is required for an action.
+
+    Special action "external_pr" runs the duplicate-PR pre-flight check
+    (gov.external_pr_check) before any other governance evaluation.
+    Context for external_pr should include {"target_repo": "owner/name",
+    "author": "github-username"} (author optional but recommended).
+    Verdict "duplicate" is propagated to callers as a hard stop.
+    """
     if not _is_initialized(repo):
         return _not_init_response("gov.evaluate", action=action, repo=repo)
+
+    # Pre-flight: external PR submission must check for duplicates first
+    if action == "external_pr":
+        target_repo = (context or {}).get("target_repo")
+        if not target_repo:
+            return {
+                "tool": "gov.evaluate",
+                "status": "evaluated",
+                "action": action,
+                "verdict": "missing_input",
+                "error": "external_pr action requires context.target_repo",
+            }
+        author = (context or {}).get("author")
+        check = external_pr_check(repo=target_repo, author=author)
+        # If duplicate found, fail-closed: callers should not proceed
+        if check.get("verdict") == "duplicate":
+            return {
+                "tool": "gov.evaluate",
+                "status": "evaluated",
+                "action": action,
+                "verdict": "blocked_duplicate",
+                "external_pr_check": check,
+                "next_action": (
+                    "STOP. A matching PR already exists. Review existing PR(s); "
+                    "do not draft, deliberate, or submit a duplicate."
+                ),
+            }
+        # No duplicate: still surface the check so the caller can audit
+        # the chain. Falls through to normal policy evaluation below.
+        external_check_result = check
+    else:
+        external_check_result = None
+
     # Governance is initialized -- evaluate against loaded policy
     repo_path = Path(repo).resolve()
     policies_file = repo_path / ".delimit" / "policies.yml"
@@ -169,7 +209,7 @@ def evaluate_trigger(action: str, context: Optional[Dict] = None, repo: str = ".
         rules = data.get("rules", []) if isinstance(data, dict) else []
     except Exception:
         rules = []
-    return {
+    result = {
         "tool": "gov.evaluate",
         "status": "evaluated",
         "action": action,
@@ -178,6 +218,11 @@ def evaluate_trigger(action: str, context: Optional[Dict] = None, repo: str = ".
         "governance_required": len(rules) > 0,
         "active_rules": len(rules),
     }
+    if external_check_result is not None:
+        result["external_pr_check"] = external_check_result
+        result["verdict"] = "ready_for_deliberation"
+        result["next_action"] = "Run delimit_deliberate, then submit the PR."
+    return result
 
 
 def new_task(title: str, scope: str, risk_level: str = "medium", repo: str = ".") -> Dict[str, Any]:
@@ -240,4 +285,125 @@ def require_owner_approval(context: str, repo: str = ".") -> Dict[str, Any]:
         "status": "checked",
         "approval_required": False,
         "context": context,
+    }
+
+
+def external_pr_check(
+    repo: str,
+    author: Optional[str] = None,
+    state: str = "all",
+) -> Dict[str, Any]:
+    """Pre-PR duplicate guard. Lists existing PRs from `author` against `repo`.
+
+    Returned verdict is fail-closed: any matching PR (open OR recently merged
+    within 30 days OR pending review) returns verdict='duplicate' so callers
+    can stop drafting before deliberation/submission.
+
+    Args:
+        repo: External GitHub repo, e.g. "goharbor/harbor".
+        author: GitHub username to filter by. If None, lists all PRs.
+        state: "open" | "closed" | "merged" | "all". Default "all" (broad).
+
+    Returns dict with:
+        verdict: "no_duplicate" | "duplicate" | "gh_unavailable" | "error"
+        prs: List of matching PR records (number, state, reviewDecision, url, mergedAt)
+        guidance: Human-readable next-step hint.
+    """
+    if not repo or "/" not in repo:
+        return {
+            "tool": "gov.external_pr_check",
+            "verdict": "error",
+            "error": "repo must be in 'owner/name' format",
+        }
+
+    cmd = ["gh", "pr", "list", "--repo", repo, "--state", state, "--limit", "50",
+           "--json", "number,title,state,reviewDecision,createdAt,mergedAt,url,author"]
+    if author:
+        cmd.extend(["--author", author])
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+    except FileNotFoundError:
+        return {
+            "tool": "gov.external_pr_check",
+            "verdict": "gh_unavailable",
+            "error": "gh CLI not installed",
+            "guidance": "Install gh (https://cli.github.com) or run `gh pr list --repo "
+                        f"{repo}" + (f" --author {author}" if author else "") + "` manually before drafting.",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "tool": "gov.external_pr_check",
+            "verdict": "error",
+            "error": "gh pr list timed out after 20s",
+        }
+
+    if proc.returncode != 0:
+        # Most common reason: not authenticated
+        stderr = (proc.stderr or "").strip()[:300]
+        return {
+            "tool": "gov.external_pr_check",
+            "verdict": "error",
+            "error": f"gh pr list failed: {stderr}",
+            "guidance": "Run `gh auth status` to verify authentication.",
+        }
+
+    try:
+        prs = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return {
+            "tool": "gov.external_pr_check",
+            "verdict": "error",
+            "error": f"could not parse gh output: {exc}",
+        }
+
+    # Fail-closed criteria: any open PR, or any PR merged in the last 30 days
+    import time as _time
+    from datetime import datetime, timezone, timedelta
+    cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+
+    duplicates = []
+    for pr in prs:
+        is_open = pr.get("state") == "OPEN"
+        merged_at = pr.get("mergedAt")
+        recently_merged = False
+        if merged_at:
+            try:
+                # gh returns ISO8601 like "2026-04-10T11:15:13Z"
+                ts = datetime.fromisoformat(merged_at.replace("Z", "+00:00"))
+                recently_merged = ts >= cutoff
+            except Exception:
+                pass
+        if is_open or recently_merged:
+            duplicates.append({
+                "number": pr.get("number"),
+                "title": pr.get("title"),
+                "state": pr.get("state"),
+                "reviewDecision": pr.get("reviewDecision"),
+                "createdAt": pr.get("createdAt"),
+                "mergedAt": merged_at,
+                "url": pr.get("url"),
+                "author": (pr.get("author") or {}).get("login"),
+            })
+
+    if duplicates:
+        return {
+            "tool": "gov.external_pr_check",
+            "verdict": "duplicate",
+            "repo": repo,
+            "author": author,
+            "prs": duplicates,
+            "guidance": (
+                f"Found {len(duplicates)} existing PR(s) — DO NOT draft a duplicate. "
+                "Review the existing PR(s) and decide: monitor, comment, or update."
+            ),
+        }
+
+    return {
+        "tool": "gov.external_pr_check",
+        "verdict": "no_duplicate",
+        "repo": repo,
+        "author": author,
+        "checked_count": len(prs),
+        "guidance": "Safe to proceed with drafting. Run delimit_deliberate before submitting.",
     }

--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -2045,6 +2045,33 @@ def delimit_gov_verify(task_id: str = "", repo: str = ".") -> Dict[str, Any]:
     return _delimit_gov_impl(action="verify", task_id=task_id, repo=repo)
 
 
+@mcp.tool()
+def delimit_external_pr_check(
+    repo: str,
+    author: str = "",
+    state: str = "all",
+) -> Dict[str, Any]:
+    """Pre-PR duplicate guard for external repos. Run BEFORE drafting.
+
+    Lists existing PRs from `author` against `repo` via gh CLI. Returns
+    fail-closed verdict — any open PR or PR merged in the last 30 days
+    yields verdict='duplicate' so the caller stops drafting before any
+    deliberation or submission work.
+
+    Args:
+        repo: External GitHub repo, e.g. "goharbor/harbor".
+        author: GitHub username to filter by (recommended). Empty = all.
+        state: "open" | "closed" | "merged" | "all". Default "all".
+    """
+    from backends.governance_bridge import external_pr_check
+    return _safe_call(
+        external_pr_check,
+        repo=repo,
+        author=author or None,
+        state=state,
+    )
+
+
 # ─── Memory ─────────────────────────────────────────────────────────────
 
 @mcp.tool()

--- a/lib/delimit-template.js
+++ b/lib/delimit-template.js
@@ -48,6 +48,11 @@ These rules fire automatically. Call the listed tools without asking permission.
 - Deploy succeeds: \`delimit_deploy_verify\` + \`delimit_evidence_collect\`
 - Verify succeeds: \`delimit_ledger_done\` (related task) + \`delimit_notify\`
 
+### Pre-External-PR Gate (any PR to a repo you don't own)
+- BEFORE drafting: call \`delimit_external_pr_check(repo, author)\`. Verdict \`duplicate\` is a hard stop — do not draft, deliberate, or submit.
+- BEFORE submitting: call \`delimit_deliberate\` on the diff + PR description.
+- The two gates compose: \`delimit_gov_evaluate(action="external_pr", context={"target_repo": "...", "author": "..."})\` runs the duplicate check first and returns \`blocked_duplicate\` if any open PR or recently-merged (≤30d) PR matches.
+
 ### Audit Trail
 - After security audit, test run, or deploy: call \`delimit_evidence_collect\`
 - Any gate failure: \`delimit_evidence_collect\` + \`delimit_ledger_add\` + \`delimit_notify\`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.3.4",
+  "version": "4.4.0",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary

New MCP tool `delimit_external_pr_check(repo, author)` plus the `gov_evaluate(action="external_pr")` composition. Pre-flight gate that runs `gh pr list` against any external repo and returns a fail-closed verdict if a matching open PR (or recently-merged PR within 30 days) already exists.

## Why

Triggered by an actual incident this session: stale outreach signals (signals.json captured 11 days earlier than current state) led an autonomous tick to draft a duplicate PR for `goharbor/harbor#23089`, which was already open and APPROVED. The duplicate was caught by founder review, not by tooling. This tool turns a one-line `gh pr list` check into a fail-closed governance gate so the same mistake can't happen autonomously.

## Changes

- `gateway/ai/server.py` — new top-level `delimit_external_pr_check` MCP tool
- `gateway/ai/backends/governance_bridge.py` — `external_pr_check()` function + `evaluate_trigger()` handles `action="external_pr"`
- `lib/delimit-template.js` — CLAUDE.md auto-trigger rule added: BEFORE drafting any external-repo PR, the duplicate gate must pass
- `CHANGELOG.md` — 4.4.0 headline added
- `package.json` — bump 4.3.4 → 4.4.0 (minor, additive)

## Verdicts

- `no_duplicate` — safe to proceed; run `delimit_deliberate`, then submit
- `duplicate` — STOP; do not draft, deliberate, or submit
- `gh_unavailable` — fail informative; manual `gh pr list` instructed
- `error` — actionable error message (auth failure → `gh auth status` hint)

## Test plan

- [x] 12 unit tests (test_external_pr_check.py): open PR, recently-merged, old merged, closed, gh missing, gh timeout, gh auth failure, missing target_repo, blocked_duplicate via gov_evaluate, ready_for_deliberation via gov_evaluate, no-author filter
- [x] End-to-end live test: caught real Harbor PR #23089 with verdict=duplicate in <500ms
- [x] Broader gateway suite: 819 passed, 1 pre-existing unrelated failure (test_byok), 9 skipped
- [x] npm test: 165/165
- [x] Tool count: 186 → 187 (auto-detected, features.json rebuilt)

## Backwards compatibility

100% additive. No existing tool changed. Existing customers' workflows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)