### PR TITLE
fix(security): LED-1180 canonicalize() — sign full content not just shape (v4.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+
+## [4.5.1] - 2026-04-28
+
+### Security — attestation `canonicalize()` strengthened (LED-1180)
+
+The `canonicalize()` helper used to derive attestation IDs and HMAC signatures was passing `Object.keys(bundle).sort()` as the second argument to `JSON.stringify`. JSON.stringify treats that argument as a property **allowlist**, not a sort order, and the allowlist contained only top-level keys — so nested objects serialised as `{}` and the HMAC committed only to the bundle's top-level shape.
+
+Practical effect: a bundle with `{governance: {violations: ["safe"]}}` and one with `{governance: {violations: ["malicious"]}}` produced **identical signatures**. Tampering nested fields was undetectable through signature verification.
+
+**This release replaces canonicalize with a proper recursive sorted-key serializer.** Old (v4.3 – v4.5.0) attestations remain readable but verify with the new canonicalize and will report `signature_mismatch`. New attestations produced by v4.5.1+ commit to the full content of the bundle.
+
+- `lib/wrap-engine.js` — fixed `canonicalize()`, exported it for reuse
+- `lib/trust-page-engine.js` — verifier now imports the corrected canonicalize
+- `tests/v43-wrap-engine.test.js` — added LED-1180 regression: tampering a nested field MUST change the signature; if it doesn't, canonicalize is silently dropping nested keys
+- `tests/v43-trust-page-engine.test.js` — test fixtures sign with the corrected canonicalize
+
+If you have a corpus of v4.5.0 or earlier attestations and need them re-signed under the new primitive, the migration tool is on the LED-1180 follow-up. For most users, attestations are short-lived merge-decision artifacts and re-signing is unnecessary.
+
+### Other
+
+- (Internal) LED-1175 + LED-1177 MVP shipped in `delimit-private`: signed deliberation attestations + Scanner Input v0 schema. Public docs: [delimit.ai/docs/scanner-input](https://delimit.ai/docs/scanner-input), [delimit.ai/docs/vs-bugcrawl](https://delimit.ai/docs/vs-bugcrawl). No customer-facing CLI changes in 4.5.1.
+
+## [4.5.0] - 2026-04-27
+
+### Added — Ledger hygiene toolkit (LED-1145, 7 PRs)
+
+The full hygiene loop is now a single MCP surface — call `delimit_ledger_health` to see what's wrong, then run the suggested tool to fix it.
+
+- **`delimit_ledger_health`** — one-shot traffic-light status (P0 inflation / stale / duplicates / garbage venture) with ranked next-action list
+- **`delimit_ledger_groom`** — read-only proposal: stale-open + duplicate-titles + garbage-venture detection. Each proposal includes a copy-pasteable `delimit_ledger_bulk` invocation
+- **`delimit_ledger_bulk(item_ids, action, dry_run=True)`** — batch operations (`archive`, `set_status`, `set_priority`, `add_tag`, `mark_done`, `cancel`). `dry_run=True` is the safety default. **No hard delete** — archive is an append-only soft transition
+- **`delimit_ledger_auto_close_external`** — find LEDs linked to a GitHub issue/PR and auto-close when the upstream resolves (mark_done for merged PRs / closed-as-completed; archive for not_planned closures)
+- **`delimit_ledger_auto_cancel_stale`** — auto-archive items dormant past `DELIMIT_STALE_TTL_DAYS` (default 60). Composes `bulk_action(archive)`. dry_run default
+- **Extended `delimit_ledger_list`** — new filters: `status_in`, `priority_in`, `tags_contains_all`, `text`, `linked_external_id`, `created_before/after`, `updated_before/after`, `sort`, `order`, `fields` projection (`"slim"` / explicit list / unknown=error), cursor pagination
+- **P0 soft-quota** on `delimit_ledger_add` — soft warning when count > `DELIMIT_P0_SOFT_QUOTA` (default 50). Item still added; surfaces a nudge to groom
+
+### Added — Memory-system convergence (LED-1165)
+
+`delimit_memory` is now the canonical durable memory; Claude Code auto-memory becomes a one-way client projection.
+
+- **`hot_load: bool` parameter** on `delimit_memory_store` — opt-in, default False. Marks an entry for projection
+- **`delimit_memory_index(target_path, dry_run, limit)`** — projects hot_load=True entries into a managed section of MEMORY.md (`<!-- delimit:start -->` / `<!-- delimit:end -->` markers). User content outside markers is preserved verbatim. **One-way only** — never reads MEMORY.md back into delimit_memory
+
+### Fixed — Secret-scanner false positives in `tools_infra`
+
+The `_CREDENTIAL_FALSE_POSITIVES` regex now suppresses three additional benign patterns so legitimate credential-loading code (env-var lookup, dict-getter, control-flow guards) doesn't trip the audit:
+- `\w+\.get(` (any object-method getter, was tokens-only)
+- `if not <var>:` (Python control-flow with credential variable)
+- `:\n` matched-text (block-opener colon, not key-value separator)
+
+### Fixed — OpenAPI diff engine defensive coverage
+
+Real-world specs can ship malformed shapes. The diff engine now defends against the entire dict-iteration crash class without losing any actual finding:
+
+- **`required: bool` in object schemas** (legal in parameter objects but seen leaking into nested schemas) — was raising `TypeError: 'bool' object is not iterable`. Treats as no-required-fields and continues
+- **`properties: [...]` instead of dict** (Kong-class) — `.keys()` no longer crashes; treats as empty properties and continues
+- **`paths: []`, `responses: []`, `content: []` (request and response)** — all coerce to `{}` at function entry. Diffs against the well-formed side still produce correct findings
+
+### Tests
+- 108 ledger-manager tests (15 originals + 93 new across 7 features + E2E hygiene-loop integration)
+- 24 memory-bridge tests (new test file)
+- 60 diff-engine tests (49 + 11 new defensive)
+- All backward-compatible — existing test suites pass without modification
+
+### Backward compatibility
+- All MCP tool parameter additions are optional with safe defaults
+- Existing storage format is unchanged (`hot_load` and `archived` are additive on the entry/status side)
+- No CLI command renamed or removed
+- Default `delimit_ledger_list` response shape preserved (full record by default; `fields="slim"` opts into the 90% payload reduction)
+
 ## [4.4.0] - 2026-04-25
 
 ### Added — Pre-external-PR duplicate guard

--- a/adapters/cursor-rules.js
+++ b/adapters/cursor-rules.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Delimit Governance Rules for Cursor
+ *
+ * Cursor doesn't have a hook system like Claude Code or Codex,
+ * so governance enforcement happens server-side via MCP tool calls.
+ * This adapter manages the .cursorrules and .cursor/rules/ files
+ * that guide Cursor's behavior.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { upsertManagedSection } = require('../lib/managed-section');
+
+// LED-213: Import canonical template for cross-model parity
+const { getDelimitSection } = require('../lib/delimit-template');
+
+const HOME = process.env.HOME || '';
+const CURSOR_DIR = path.join(HOME, '.cursor');
+const CURSOR_RULES_DIR = path.join(CURSOR_DIR, 'rules');
+const CURSORRULES_FILE = path.join(HOME, '.cursorrules');
+
+/**
+ * Install Delimit governance rules into Cursor.
+ * Creates both .cursorrules (legacy) and .cursor/rules/delimit.md (new).
+ */
+function installRules(version) {
+    const rules = getDelimitRules(version);
+
+    // Install to .cursor/rules/delimit.md (new location, Cursor 0.45+).
+    // LED-1180 follow-up: use upsertManagedSection so user-customized
+    // content above/below the delimit:start/end markers is preserved.
+    // The previous implementation did fs.writeFileSync(rulesFile, rules)
+    // — full overwrite — which clobbered any user customizations on every
+    // `delimit-cli setup`.
+    let action = 'unchanged';
+    let rulesFile = null;
+    if (fs.existsSync(CURSOR_DIR)) {
+        fs.mkdirSync(CURSOR_RULES_DIR, { recursive: true });
+        rulesFile = path.join(CURSOR_RULES_DIR, 'delimit.md');
+        const result = upsertManagedSection(rulesFile, rules, version);
+        action = result.action;
+    }
+
+    return {
+        installed: true,
+        action,
+        paths: [CURSORRULES_FILE, path.join(CURSOR_RULES_DIR, 'delimit.md')],
+    };
+}
+
+/**
+ * Remove Delimit rules from Cursor.
+ */
+function uninstallRules() {
+    const removed = [];
+
+    // Remove from .cursor/rules/
+    const rulesFile = path.join(CURSOR_RULES_DIR, 'delimit.md');
+    if (fs.existsSync(rulesFile)) {
+        fs.unlinkSync(rulesFile);
+        removed.push(rulesFile);
+    }
+
+    return { removed };
+}
+
+function getDelimitRules(version) {
+    // LED-213: Use canonical Consensus 123 template for Cursor parity
+    return getDelimitSection();
+}
+
+module.exports = { installRules, uninstallRules, getDelimitRules };
+
+// CLI entry point
+if (require.main === module) {
+    const action = process.argv[2] || 'install';
+    const version = process.argv[3] || '3.11.9';
+    if (action === 'install') {
+        const result = installRules(version);
+        console.log(`Installed Delimit rules to Cursor: ${result.paths.join(', ')}`);
+    } else if (action === 'uninstall') {
+        const result = uninstallRules();
+        console.log(`Removed: ${result.removed.join(', ') || 'nothing to remove'}`);
+    }
+}

--- a/lib/managed-section.js
+++ b/lib/managed-section.js
@@ -1,0 +1,92 @@
+// lib/managed-section.js
+//
+// Shared upsertDelimitSection helper. Used by:
+//   bin/delimit-setup.js — for ~/CLAUDE.md, ~/.codex/instructions.md, ~/.cursorrules
+//   adapters/cursor-rules.js — for ~/.cursor/rules/delimit.md
+//
+// NEVER clobbers user-authored content outside the markers. Behavior:
+//   - File missing → create with just the managed section.
+//   - File has markers → replace only the region between them (user content
+//     above/below preserved).
+//   - File has no markers → append the managed section at the bottom (user
+//     content at top preserved).
+//
+// History (institutional memory; do NOT change marker semantics without
+// understanding these incidents):
+//   - v4.1.47: previous heuristic replaced the whole file whenever it
+//     detected "old Delimit content" — destroyed founder-customized
+//     CLAUDE.md files on every upgrade.
+//   - v4.1.49: unanchored marker regex matched markers inside quoted
+//     prose (backticks, bullets, blockquotes) — clobbered /root/CLAUDE.md.
+//     The current regex is anchored with the multiline flag so markers
+//     MUST be on their own line. Optional leading horizontal whitespace
+//     [ \t]* permits genuinely indented markers but NOT prose-leading
+//     characters like "- ", "> ", "`", "*".
+//
+// Returns: { action: 'created' | 'updated' | 'unchanged' | 'appended' }
+
+const fs = require('fs');
+const path = require('path');
+
+function loadPackageVersion() {
+    try {
+        const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
+        return pkg.version || '0.0.0';
+    } catch {
+        return '0.0.0';
+    }
+}
+
+/**
+ * Upsert the Delimit section in a file using <!-- delimit:start v<version> -->
+ * and <!-- delimit:end --> markers.
+ *
+ * @param {string} filePath - Absolute path to the target file.
+ * @param {string} newSection - The full managed-section text (including markers).
+ * @param {string} [version] - Version string for staleness check. Defaults to package.json.
+ * @returns {{action: 'created'|'updated'|'unchanged'|'appended'}}
+ */
+function upsertManagedSection(filePath, newSection, version) {
+    if (!version) version = loadPackageVersion();
+
+    if (!fs.existsSync(filePath)) {
+        fs.writeFileSync(filePath, newSection + '\n');
+        return { action: 'created' };
+    }
+
+    const rawExisting = fs.readFileSync(filePath, 'utf-8');
+    // Strip a UTF-8 BOM if present so the start-of-line anchor still matches
+    // the very first line of the file. We write back the stripped form to keep
+    // serialization deterministic.
+    const existing = rawExisting.replace(/^﻿/, '');
+
+    const startMarkerRe = /^[ \t]*<!-- delimit:start[^>]*-->[ \t]*$/m;
+    const endMarkerRe = /^[ \t]*<!-- delimit:end -->[ \t]*$/m;
+    const startMatch = existing.match(startMarkerRe);
+    const endMatch = existing.match(endMarkerRe);
+
+    if (startMatch && endMatch) {
+        // Extract current version from the marker (also anchored, allows indent)
+        const versionMatch = existing.match(/^[ \t]*<!-- delimit:start v([^ ]+) -->[ \t]*$/m);
+        const currentVersion = versionMatch ? versionMatch[1] : '';
+        if (currentVersion === version) {
+            return { action: 'unchanged' };
+        }
+        // Replace only the managed region — preserve content above/below
+        const startIdx = startMatch.index;
+        const endIdx = endMatch.index + endMatch[0].length;
+        const before = existing.substring(0, startIdx);
+        const after = existing.substring(endIdx);
+        fs.writeFileSync(filePath, before + newSection + after);
+        return { action: 'updated' };
+    }
+
+    // No markers present — append the managed section at the bottom.
+    // User content above is preserved verbatim. Markers get added so future
+    // upgrades can update just the managed region.
+    const separator = existing.endsWith('\n') ? '\n' : '\n\n';
+    fs.writeFileSync(filePath, existing + separator + newSection + '\n');
+    return { action: 'appended' };
+}
+
+module.exports = { upsertManagedSection, loadPackageVersion };

--- a/lib/trust-page-engine.js
+++ b/lib/trust-page-engine.js
@@ -10,6 +10,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { canonicalize } = require('./wrap-engine');
 
 function loadHmacKey() {
     const keyPath = path.join(os.homedir(), '.delimit', 'wrap-hmac.key');
@@ -20,8 +21,11 @@ function loadHmacKey() {
 function verifySignature(attestation, key) {
     if (!key) return 'unverifiable';
     try {
-        const canonical = JSON.stringify(attestation.bundle, Object.keys(attestation.bundle).sort());
-        const expected = crypto.createHmac('sha256', key).update(canonical).digest('hex');
+        // LED-1180: must use the same recursive sorted-key canonicalize
+        // as wrap-engine; using JSON.stringify(.., keys.sort()) here
+        // would treat the array as an allowlist and serialise nested
+        // fields as {}, matching the old broken signature trivially.
+        const expected = crypto.createHmac('sha256', key).update(canonicalize(attestation.bundle)).digest('hex');
         return expected === attestation.signature ? 'verified' : 'signature_mismatch';
     } catch {
         return 'verify_error';

--- a/lib/wrap-engine.js
+++ b/lib/wrap-engine.js
@@ -138,9 +138,26 @@ function runTestSmoke(cwd) {
 // Attestation bundling + signing
 // ----------------------------------------------------------------------------
 
+// LED-1180: deterministic canonical JSON. Recursively sorts object keys
+// at every depth. Earlier implementations passed the second argument of
+// JSON.stringify as `Object.keys(bundle).sort()`, which JSON.stringify
+// treats as a property ALLOWLIST (not a sort order), filtered to
+// top-level keys. The result was that nested objects serialised as
+// `{}` and the HMAC committed only to the top-level shape — meaning a
+// bad actor could change `bundle.governance.violations` or any nested
+// field without invalidating the signature. Fixed in v4.5.1 hotfix.
+// Verifier must use the same canonicalize to match.
+function canonicalize(value) {
+    if (value === null || typeof value !== 'object') return JSON.stringify(value);
+    if (Array.isArray(value)) {
+        return '[' + value.map(canonicalize).join(',') + ']';
+    }
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalize(value[k])).join(',') + '}';
+}
+
 function computeAttestationId(bundle) {
-    const canonical = JSON.stringify(bundle, Object.keys(bundle).sort());
-    const hash = crypto.createHash('sha256').update(canonical).digest('hex');
+    const hash = crypto.createHash('sha256').update(canonicalize(bundle)).digest('hex');
     return 'att_' + hash.slice(0, 16);
 }
 
@@ -157,8 +174,7 @@ function loadOrCreateHmacKey() {
 
 function signAttestation(bundle) {
     const key = loadOrCreateHmacKey();
-    const canonical = JSON.stringify(bundle, Object.keys(bundle).sort());
-    return crypto.createHmac('sha256', key).update(canonical).digest('hex');
+    return crypto.createHmac('sha256', key).update(canonicalize(bundle)).digest('hex');
 }
 
 // ----------------------------------------------------------------------------
@@ -442,6 +458,7 @@ async function runWrap(rawCmd, options = {}) {
 
 module.exports = {
     runWrap,
+    canonicalize,
     computeAttestationId,
     signAttestation,
     checkQuota,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.4.0",
+  "version": "4.5.1",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [

--- a/tests/setup-no-clobber.test.js
+++ b/tests/setup-no-clobber.test.js
@@ -290,3 +290,154 @@ describe('synthetic fresh-user setup: full preservation contract', () => {
         }
     });
 });
+
+// ----------------------------------------------------------------------------
+// LED-1180 follow-up: managed-section preservation contract
+// ----------------------------------------------------------------------------
+//
+// Pre-fix bug: adapters/cursor-rules.js installRules() did
+// `fs.writeFileSync(rulesFile, rules)` — full overwrite. A user who
+// customized ~/.cursor/rules/delimit.md would have their content
+// destroyed on every `delimit-cli setup`.
+//
+// Post-fix: cursor-rules now uses lib/managed-section.js which only
+// touches the region between <!-- delimit:start --> / <!-- delimit:end -->
+// markers, and appends-with-markers when no markers exist.
+//
+// These tests are the institutional safety net so the bug stays fixed.
+
+describe('LED-1180: managed-section preserves user-customized content', () => {
+    const { upsertManagedSection } = require('../lib/managed-section');
+
+    function fixture(initialContent, newSection, version) {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-managed-'));
+        const filePath = path.join(tmp, 'target.md');
+        if (initialContent !== null) fs.writeFileSync(filePath, initialContent);
+        const result = upsertManagedSection(filePath, newSection, version || '4.5.1');
+        const after = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : null;
+        return { tmp, filePath, result, after };
+    }
+
+    it('creates the file with markers when missing', () => {
+        const newSection = '<!-- delimit:start v4.5.1 -->\nrules\n<!-- delimit:end -->';
+        const { tmp, result, after } = fixture(null, newSection);
+        try {
+            assert.strictEqual(result.action, 'created');
+            assert.ok(after.includes('<!-- delimit:start v4.5.1 -->'));
+            assert.ok(after.includes('<!-- delimit:end -->'));
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('appends managed section when file exists without markers', () => {
+        const userContent = '# My custom rules\n\nLine A.\nLine B with config.\n';
+        const newSection = '<!-- delimit:start v4.5.1 -->\nrules\n<!-- delimit:end -->';
+        const { tmp, result, after } = fixture(userContent, newSection);
+        try {
+            assert.strictEqual(result.action, 'appended');
+            assert.ok(after.startsWith(userContent), 'User content MUST be preserved at top');
+            assert.ok(after.includes('<!-- delimit:start v4.5.1 -->'), 'Markers MUST be added');
+            assert.ok(after.includes(userContent.trim()));
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('replaces ONLY the managed region; preserves content above AND below', () => {
+        const before = '# Top\nMy rule one.\n';
+        const middle = '<!-- delimit:start v4.5.0 -->\nold managed body\n<!-- delimit:end -->';
+        const after = '\n## Bottom\nMy rule two with `code`.\n';
+        const initial = before + middle + after;
+
+        const newSection = '<!-- delimit:start v4.5.1 -->\nNEW managed body\n<!-- delimit:end -->';
+        const fix = fixture(initial, newSection, '4.5.1');
+        try {
+            assert.strictEqual(fix.result.action, 'updated');
+            assert.ok(fix.after.startsWith(before), 'Content above markers MUST be byte-preserved');
+            assert.ok(fix.after.endsWith(after), 'Content below markers MUST be byte-preserved');
+            assert.ok(fix.after.includes('NEW managed body'), 'Managed body MUST be replaced');
+            assert.ok(!fix.after.includes('old managed body'), 'Old managed body MUST be removed');
+        } finally {
+            fs.rmSync(fix.tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('skips write when version already matches (idempotent upgrade)', () => {
+        const initial = '# Top\n<!-- delimit:start v4.5.1 -->\nbody\n<!-- delimit:end -->\n# Bottom\n';
+        const newSection = '<!-- delimit:start v4.5.1 -->\nbody\n<!-- delimit:end -->';
+        const { tmp, result, after } = fixture(initial, newSection, '4.5.1');
+        try {
+            assert.strictEqual(result.action, 'unchanged');
+            assert.strictEqual(after, initial, 'Same-version upgrade MUST be a no-op');
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('does NOT mistake quoted markers in user prose for a real managed section', () => {
+        // v4.1.49 bug: unanchored regex matched markers inside backticks
+        // or bullet lists, and clobbered user content. Anchored regex must
+        // require markers to be on their own line.
+        const userProse = '# My rules\n\nThe markers `<!-- delimit:start -->` and `<!-- delimit:end -->` mark the managed section.\n\nMore notes.\n';
+        const newSection = '<!-- delimit:start v4.5.1 -->\nbody\n<!-- delimit:end -->';
+        const { tmp, result, after } = fixture(userProse, newSection);
+        try {
+            assert.strictEqual(result.action, 'appended', 'Quoted markers MUST NOT trigger update path');
+            assert.ok(after.startsWith(userProse), 'User prose MUST be preserved');
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('cursor-rules.installRules: preserves customized .cursor/rules/delimit.md', () => {
+        // Integration: simulate a user who customized ~/.cursor/rules/delimit.md
+        // around the delimit-managed section. Run installRules. Confirm
+        // user content is still there.
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-cursor-'));
+        const cursorDir = path.join(tmp, '.cursor');
+        const rulesDir = path.join(cursorDir, 'rules');
+        const rulesFile = path.join(rulesDir, 'delimit.md');
+        fs.mkdirSync(rulesDir, { recursive: true });
+
+        const userContent =
+            '# My personal Cursor rules\n\n' +
+            'Always use TypeScript strict mode.\nPrefer async/await over .then().\n\n' +
+            '<!-- delimit:start v4.4.0 -->\nold delimit body\n<!-- delimit:end -->\n\n' +
+            '## My epilogue\nAlways write tests.\n';
+        fs.writeFileSync(rulesFile, userContent);
+
+        const ORIGINAL_HOME = process.env.HOME;
+        process.env.HOME = tmp;
+        try {
+            // Re-require with HOME pointing at tmp so adapters/cursor-rules
+            // resolves CURSOR_DIR / CURSOR_RULES_DIR against tmp.
+            delete require.cache[require.resolve('../adapters/cursor-rules')];
+            const cursorRules = require('../adapters/cursor-rules');
+            const result = cursorRules.installRules('4.5.1');
+
+            assert.ok(result.installed);
+            const after = fs.readFileSync(rulesFile, 'utf-8');
+            assert.ok(
+                after.startsWith('# My personal Cursor rules'),
+                'User header MUST be preserved'
+            );
+            assert.ok(
+                after.includes('Always use TypeScript strict mode'),
+                'User body MUST be preserved above markers'
+            );
+            assert.ok(
+                after.includes('## My epilogue\nAlways write tests'),
+                'User content below markers MUST be preserved'
+            );
+            assert.ok(
+                !after.includes('old delimit body'),
+                'Old managed body MUST be replaced'
+            );
+        } finally {
+            process.env.HOME = ORIGINAL_HOME;
+            delete require.cache[require.resolve('../adapters/cursor-rules')];
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/v43-trust-page-engine.test.js
+++ b/tests/v43-trust-page-engine.test.js
@@ -55,8 +55,8 @@ function mintAttestation(id, wrappedCommand, key, mutate = (b) => b) {
         governance: { gates: [{ name: 'test_smoke', exit: 0 }], violations: [], advisory: true },
         delimit_wrap_version: '1.1.0',
     });
-    const canonical = JSON.stringify(bundle, Object.keys(bundle).sort());
-    const signature = crypto.createHmac('sha256', key).update(canonical).digest('hex');
+    const { canonicalize } = require('../lib/wrap-engine');
+    const signature = crypto.createHmac('sha256', key).update(canonicalize(bundle)).digest('hex');
     return { id, bundle, signature, signature_alg: 'HMAC-SHA256' };
 }
 

--- a/tests/v43-wrap-engine.test.js
+++ b/tests/v43-wrap-engine.test.js
@@ -81,13 +81,29 @@ describe('v43 wrap: attestation round-trip', () => {
         assert.ok(Array.isArray(att.bundle.governance.gates));
     });
 
-    it('signature verifies against the canonical bundle with the stored HMAC key', async () => {
+    it('signature verifies + LED-1180 nested-tamper regression', async () => {
         const result = await runWrap(['true'], { cwd: SANDBOX });
         const att = JSON.parse(fs.readFileSync(result.attestation_path, 'utf-8'));
         const key = fs.readFileSync(path.join(ATT_HOME, '.delimit', 'wrap-hmac.key'));
-        const canonical = JSON.stringify(att.bundle, Object.keys(att.bundle).sort());
-        const expected = crypto.createHmac('sha256', key).update(canonical).digest('hex');
+        const { canonicalize } = require('../lib/wrap-engine');
+
+        // Recomputed HMAC equals stored signature
+        const expected = crypto.createHmac('sha256', key).update(canonicalize(att.bundle)).digest('hex');
         assert.equal(expected, att.signature, 'recomputed HMAC must equal stored signature');
+
+        // LED-1180 regression: tampering a NESTED field MUST change the signature.
+        // Pre-fix canonicalize used JSON.stringify(bundle, Object.keys(bundle).sort()),
+        // which treats the second arg as a property allowlist (only top-level keys),
+        // so nested objects serialised as {} and the HMAC committed only to shape.
+        const tampered = JSON.parse(JSON.stringify(att.bundle));
+        if (!tampered.governance) tampered.governance = {};
+        tampered.governance.violations = [{ injected: 'malicious-rule' }];
+        const tamperedSig = crypto.createHmac('sha256', key).update(canonicalize(tampered)).digest('hex');
+        assert.notEqual(
+            tamperedSig,
+            att.signature,
+            'nested-field tamper MUST change the signature; if equal, canonicalize is silently dropping nested keys'
+        );
     });
 
     it('detects changed files in the wrapped command output', async () => {


### PR DESCRIPTION
## Summary

**Hotfix release v4.5.1.** Strengthens attestation signatures so they commit to full bundle content, not just top-level shape.

## The bug

`canonicalize()` in `lib/wrap-engine.js` was passing `Object.keys(bundle).sort()` as the second argument to `JSON.stringify`. That argument is a property **allowlist**, not a sort order, and the allowlist contained only top-level keys — so nested objects serialised as `{}` and the HMAC committed only to the top-level shape.

### Reproduce on the OLD canonicalize

```js
const broken = (b) => JSON.stringify(b, Object.keys(b).sort());
const orig     = {a:1, governance: {violations: ["safe"]}};
const tampered = {a:1, governance: {violations: ["malicious"]}};
// crypto.createHmac('sha256', key).update(broken(orig)).digest('hex')
//   ===
// crypto.createHmac('sha256', key).update(broken(tampered)).digest('hex')
// → true. Signatures match across nested-field tamper. Bug.
```

## Practical effect (v4.3 – v4.5.0)

A bundle with `bundle.governance.violations = ["safe"]` and one with `bundle.governance.violations = ["malicious"]` produced **identical signatures**. Tampering nested fields was undetectable through signature verification.

## Fix

- **`lib/wrap-engine.js`** — replace `canonicalize` with a recursive sorted-key serializer that descends into nested objects and arrays. Export it.
- **`lib/trust-page-engine.js`** — import `canonicalize` from `wrap-engine` instead of duplicating the broken inline form.
- **`tests/v43-wrap-engine.test.js`** — added LED-1180 regression: tampering `bundle.governance.violations` MUST change the signature; if it doesn't, canonicalize is silently dropping nested keys and the test fails loudly.
- **`tests/v43-trust-page-engine.test.js`** — `mintAttestation()` uses the exported canonicalize so fixtures match the engine.
- **`package.json`** — bump to `4.5.1`.
- **`CHANGELOG.md`** — disclosure entry under `[4.5.1]` with the practical-effect example and migration note.

## Compat

- Old (v4.3 – v4.5.0) attestations remain readable but verify with the new canonicalize and report `signature_mismatch` via `trust-page-engine`.
- New attestations produced by v4.5.1+ commit to full content.
- No CLI surface changes; no schema field renames.

## Test Plan

- [x] `npm test` — 165/165 pass (including the new LED-1180 nested-tamper regression)
- [ ] `delimit doctor` on a fresh install
- [ ] Pre-publish security check passes
- [ ] `delimit_security_audit` clean
- [ ] Founder approval on disclosure framing in CHANGELOG before publish

## Discovered

While building LED-1175 (signed deliberation attestation MVP). The attestation script's tamper test passed when it should have failed; root-cause to canonicalize allowlist semantics; same pattern present in 5 sites in npm-delimit (2 lib + 2 tests + 1 sweep target). All 5 corrected.

## Refs

- LED-1180 — this fix
- LED-1175, LED-1177 — discovery context
- STR-190 — the deliberation that motivated the attestation MVP

🤖 Generated with [Claude Code](https://claude.com/claude-code)