### PR TITLE
chore(readme): refresh stale badges (Action v1.6→latest, tests 165→1640+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Wrap any AI coding assistant (Claude Code, Codex, Cursor, Gemini CLI) with a governance chain that runs your gates, records what changed, and signs a replayable receipt for every merge.
 
 [![npm](https://img.shields.io/npm/v/delimit-cli)](https://www.npmjs.com/package/delimit-cli)
-[![Tests](https://img.shields.io/badge/tests-165%20passing-brightgreen)](https://github.com/delimit-ai/delimit-mcp-server)
-[![GitHub Action](https://img.shields.io/badge/GitHub%20Action-v1.6.0-blue)](https://github.com/marketplace/actions/delimit-api-governance)
+[![Tests](https://img.shields.io/badge/tests-1640%2B%20passing-brightgreen)](https://github.com/delimit-ai/delimit-mcp-server)
+[![GitHub Action](https://img.shields.io/badge/GitHub%20Action-latest-blue)](https://github.com/marketplace/actions/delimit-api-governance)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Glama](https://glama.ai/mcp/servers/delimit-ai/delimit/badge)](https://glama.ai/mcp/servers/delimit-ai/delimit)
 


### PR DESCRIPTION
Two badges drifted:
- GitHub Action v1.6.0 → \`latest\` (current is v1.11.3)
- Tests 165 → 1640+ (1420 gateway + 98 action + 123 npm)

Pure cosmetic, no content changes. The hero tagline + Think and Build section already match the North Star post-deliberation 2026-04-29 (Codex+Opus+Gemini unanimous round 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)