### PR TITLE
template+package: dispatch-rule sync + gate self-repair as gateway-only

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -4921,6 +4921,14 @@ program
     .option('--no-write', 'Do not write the preview JSON to disk')
     .action(async (kind, opts) => {
         const { recordTelemetry } = require('../lib/attest-telemetry');
+        // --write is the deprecated alias for --output. Emit a one-line
+        // notice so users migrate before we remove it. (Panel verdict on
+        // STR-656 pre-push gate, 2026-04-30: retire the alias in v4.7.)
+        if (opts.write && typeof opts.write === 'string' && !opts.output) {
+            console.error(chalk.yellow(
+                '  [deprecation] --write is deprecated; use --output instead. (will be removed in v4.7)'
+            ));
+        }
         if (kind !== 'mcp') {
             console.log(chalk.yellow(`  Unknown attestation kind: ${kind}`));
             console.log(chalk.gray('  Supported kinds (v1): mcp'));

--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -11,6 +11,7 @@ const inquirer = require('inquirer');
 const DelimitAuthSetup = require('../lib/auth-setup');
 const DelimitHooksInstaller = require('../lib/hooks-installer');
 const crossModelHooks = require('../lib/cross-model-hooks');
+const { delimitHome, homeSubpath } = require('../lib/delimit-home');
 const {
     resolveContinuityContext,
     formatContinuityReport,
@@ -58,8 +59,8 @@ function normalizeNaturalLanguageArgs(argv) {
     const raw = argv.slice(2);
     if (raw.length === 0) {
         // First-run detection: if no ~/.delimit exists, show welcome flow
-        const delimitHome = path.join(os.homedir(), '.delimit');
-        if (!fs.existsSync(delimitHome) || !fs.existsSync(path.join(delimitHome, 'server'))) {
+        const home = delimitHome();
+        if (!fs.existsSync(home) || !fs.existsSync(path.join(home, 'server'))) {
             return ['scan'];  // lowest friction entry point for new users
         }
         return resolveRepoRoot(process.cwd()) ? ['session', '--inspect'] : ['session', '--all'];
@@ -1093,8 +1094,7 @@ program
     .option('--dry-run', 'Preview what would be removed without making changes')
     .action(async (options) => {
         const dryRun = options.dryRun;
-        const HOME = process.env.HOME;
-        const backupDir = path.join(HOME, '.delimit', 'backups', `uninstall-${Date.now()}`);
+        const backupDir = homeSubpath('backups', `uninstall-${Date.now()}`);
         const changes = [];
 
         if (dryRun) {
@@ -1349,8 +1349,7 @@ program
 
 // Helper function for installation
 async function installDelimit(mode, scope, hooksType = 'all') {
-    const HOME = process.env.HOME;
-    const DELIMIT_HOME = path.join(HOME, '.delimit');
+    const DELIMIT_HOME = delimitHome();
     
     // Create directories
     ['bin', 'hooks', 'shims', 'config', 'audit', 'credentials'].forEach(dir => {
@@ -2554,7 +2553,7 @@ program
     .action(async () => {
         console.log(chalk.bold('\n  Delimit — Resume Work\n'));
 
-        const DELIMIT_HOME = path.join(os.homedir(), '.delimit');
+        const DELIMIT_HOME = delimitHome();
 
         // 1. Last session handoff
         const sessionsDir = path.join(DELIMIT_HOME, 'sessions');
@@ -3285,10 +3284,10 @@ program
     .option('--format <fmt>', 'Output format: md, json, html', 'md')
     .option('--output <file>', 'Write report to file instead of stdout')
     .action(async (options) => {
-        const delimitHome = path.join(os.homedir(), '.delimit');
-        const evidenceDir = path.join(delimitHome, 'evidence');
-        const ledgerDir = path.join(delimitHome, 'ledger');
-        const memoryDir = path.join(delimitHome, 'memory');
+        const home = delimitHome();
+        const evidenceDir = path.join(home, 'evidence');
+        const ledgerDir = path.join(home, 'ledger');
+        const memoryDir = path.join(home, 'memory');
 
         // Parse duration into milliseconds
         function parseDuration(dur) {
@@ -4906,6 +4905,86 @@ program
         }
     });
 
+// STR-656 — `delimit attest mcp` local-preview command (no public attestation,
+// no badge, no publish). Per the methodology gate (STR-657) the public signed-
+// attestation surface is locked until: 30d methodology visibility +
+// 14d CLI shipped + 5+ merge-gate pilot reference accounts + incident-
+// response process documented. This command exists so maintainers can
+// run the methodology checks locally and see the preview report shape.
+program
+    .command('attest <kind>')
+    .description('Run a Delimit attestation methodology check locally (preview only).  kind: mcp')
+    .option('--path <dir>', 'Path to repo (default: cwd)')
+    .option('--json', 'Emit machine-readable JSON instead of the text preview')
+    .option('--output <file>', 'Write the preview JSON to a file (default: .delimit/attestation-preview.json)')
+    .option('--write <file>', '(deprecated) alias for --output')
+    .option('--no-write', 'Do not write the preview JSON to disk')
+    .action(async (kind, opts) => {
+        const { recordTelemetry } = require('../lib/attest-telemetry');
+        if (kind !== 'mcp') {
+            console.log(chalk.yellow(`  Unknown attestation kind: ${kind}`));
+            console.log(chalk.gray('  Supported kinds (v1): mcp'));
+            console.log(chalk.gray('  pr-review and release attestations land in a follow-up.'));
+            recordTelemetry({ kind, outcome: 'unknown_kind' });
+            process.exitCode = 2;
+            return;
+        }
+        const { runAttestMcp, renderPreview } = require('../lib/attest-mcp');
+        let report;
+        try {
+            report = await runAttestMcp({ path: opts.path });
+        } catch (e) {
+            console.log(chalk.red(`  attest mcp crashed: ${e.message}`));
+            recordTelemetry({ kind: 'mcp', outcome: 'runner_crash', error: e.message });
+            process.exitCode = 2;
+            return;
+        }
+        if (report.error) {
+            console.log(chalk.red(`  ${report.error}`));
+            recordTelemetry({ kind: 'mcp', outcome: 'runner_error', error: report.error });
+            process.exitCode = 2;
+            return;
+        }
+        if (opts.json) {
+            console.log(JSON.stringify(report, null, 2));
+        } else {
+            console.log(renderPreview(report));
+        }
+        // Write the JSON report unless --no-write was given. --output wins,
+        // --write is the deprecated alias kept for ≥1 minor cycle.
+        if (opts.write !== false) {
+            const outPath = opts.output || opts.write ||
+                path.join(report.repo.path, '.delimit', 'attestation-preview.json');
+            try {
+                fs.mkdirSync(path.dirname(outPath), { recursive: true });
+                fs.writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n');
+                if (!opts.json) console.log(chalk.gray(`  Preview JSON: ${outPath}\n`));
+            } catch (e) {
+                // Soft-fail: a read-only filesystem (EROFS) or permissions
+                // issue must NOT elevate the exit code — the report itself
+                // is on stdout already.
+                if (!opts.json) {
+                    console.log(chalk.yellow(`  could not write preview JSON (${e.code || 'IO'}): ${e.message}`));
+                }
+            }
+        }
+        // 3-tier exit codes (panel verdict on STR-656 scaffold review):
+        //   0 — pass + skip (no policy failure, no tool error)
+        //   1 — at least one check returned fail (policy violation)
+        //   2 — at least one check returned error (tool unavailable / unreadable input)
+        // Skips do NOT raise the exit code; they are evidence states, not failures.
+        const anyFail = report.checks.some((c) => c.status === 'fail');
+        const anyError = report.checks.some((c) => c.status === 'error');
+        const exitCode = anyFail ? 1 : (anyError ? 2 : 0);
+        recordTelemetry({
+            kind: 'mcp',
+            outcome: ['pass', 'fail', 'error'][exitCode],
+            methodology_version: report.methodology_version,
+            check_summary: report.checks.map((c) => `${c.id}:${c.status}`).join(','),
+        });
+        process.exitCode = exitCode;
+    });
+
 // CI command — generate GitHub Action workflow
 program
     .command('ci')
@@ -5477,8 +5556,7 @@ program
     .command('activate <key>')
     .description('Activate a Delimit Pro license key')
     .action(async (key) => {
-        const os = require('os');
-        const licenseDir = path.join(os.homedir(), '.delimit');
+        const licenseDir = delimitHome();
         const licensePath = path.join(licenseDir, 'license.json');
 
         if (!key || key.length < 10) {
@@ -5766,8 +5844,7 @@ program
             console.log(`Question: ${chalk.bold(question)}\n`);
 
             // Try to run deliberation directly via the gateway
-            const HOME = process.env.HOME || require('os').homedir();
-            const gatewayScript = path.join(HOME, '.delimit', 'server', 'ai', 'deliberation.py');
+            const gatewayScript = homeSubpath('server', 'ai', 'deliberation.py');
             const scriptPath = fs.existsSync(gatewayScript) ? gatewayScript : null;
 
             if (scriptPath) {
@@ -5809,7 +5886,7 @@ if result.get('summary'):
             }
 
             // Save pending deliberation to file for reference
-            const deliberationDir = path.join(HOME, '.delimit', 'deliberation');
+            const deliberationDir = homeSubpath('deliberation');
             fs.mkdirSync(deliberationDir, { recursive: true });
             const pending = {
                 question,
@@ -5848,8 +5925,8 @@ if result.get('summary'):
 // Models command: BYOK deliberation key management wizard
 // ---------------------------------------------------------------------------
 
-const MODELS_CONFIG_PATH = path.join(os.homedir(), '.delimit', 'models.json');
-const DELIBERATION_USAGE_PATH = path.join(os.homedir(), '.delimit', 'deliberation_usage.json');
+const MODELS_CONFIG_PATH = homeSubpath('models.json');
+const DELIBERATION_USAGE_PATH = homeSubpath('deliberation_usage.json');
 
 const DEFAULT_MODELS = {
     grok: { enabled: false, api_key: '', model: 'grok-4-0709', name: 'Grok 4' },
@@ -6199,7 +6276,7 @@ program
 program
     .command('trust-page')
     .description('Render attestations into a public trust page (static HTML + JSON feed)')
-    .option('-d, --dir <path>', 'Attestation directory', path.join(os.homedir(), '.delimit', 'attestations'))
+    .option('-d, --dir <path>', 'Attestation directory', homeSubpath('attestations'))
     .option('-o, --out <path>', 'Output directory', './trust-page')
     .option('-t, --title <title>', 'Trust page title', 'Trust Page')
     .option('--json', 'Output result as JSON', false)
@@ -6229,7 +6306,7 @@ program
 program
     .command('ai-sbom')
     .description('Build a CycloneDX-AI bill of materials from attestations')
-    .option('-d, --dir <path>', 'Attestation directory', path.join(os.homedir(), '.delimit', 'attestations'))
+    .option('-d, --dir <path>', 'Attestation directory', homeSubpath('attestations'))
     .option('-o, --out <path>', 'Output file', './ai-sbom.json')
     .option('-n, --name <name>', 'BOM subject name', 'ai-sbom')
     .option('-v, --package-version <v>', 'BOM subject version', '1.0.0')
@@ -6292,7 +6369,7 @@ program
             console.log("\nUse " + chalk.cyan("delimit vault list") + " to see configured secrets.");
         } else if (action === "list") {
             console.log(chalk.bold("Configured Secrets:"));
-            const secretsDir = path.join(os.homedir(), '.delimit', 'secrets');
+            const secretsDir = homeSubpath('secrets');
             if (fs.existsSync(secretsDir)) {
                 const files = fs.readdirSync(secretsDir).filter(f => f.endsWith('.json') && !f.startsWith('.'));
                 if (files.length === 0) {
@@ -6314,7 +6391,7 @@ program
                 console.log(chalk.dim("  Example: delimit vault set OPENAI_API_KEY"));
                 process.exit(1);
             }
-            const secretsDir = path.join(os.homedir(), '.delimit', 'secrets');
+            const secretsDir = homeSubpath('secrets');
             fs.mkdirSync(secretsDir, { recursive: true });
             const filePath = path.join(secretsDir, `${name}.json`);
             const existing = fs.existsSync(filePath);
@@ -6338,7 +6415,7 @@ program
                 console.log(chalk.red("Usage: delimit vault reveal <NAME>"));
                 process.exit(1);
             }
-            const secretsDir = path.join(os.homedir(), '.delimit', 'secrets');
+            const secretsDir = homeSubpath('secrets');
             const filePath = path.join(secretsDir, `${name}.json`);
             if (!fs.existsSync(filePath)) {
                 console.log(chalk.red(`  Secret "${name}" not found.`));
@@ -6399,7 +6476,7 @@ program
 // Memory commands: remember, recall, forget
 // ---------------------------------------------------------------------------
 
-const MEMORY_DIR = path.join(os.homedir(), '.delimit', 'memory');
+const MEMORY_DIR = homeSubpath('memory');
 const MEMORY_FILE = path.join(MEMORY_DIR, 'memories.jsonl');
 
 const KNOWN_TECH_TERMS = new Set([

--- a/lib/attest-mcp.js
+++ b/lib/attest-mcp.js
@@ -1,0 +1,487 @@
+'use strict';
+
+/**
+ * STR-656 — `delimit attest mcp` local-preview implementation.
+ *
+ * Runs the five deterministic checks defined by the MCP Attestation
+ * Methodology v1 (delimit.ai/methodology/mcp-attestation) and prints a
+ * PREVIEW REPORT. This module deliberately does NOT sign anything, does
+ * NOT publish to delimit.ai, does NOT generate a badge.
+ *
+ * The methodology gate (STR-657) keeps the public signed-attestation
+ * surface locked until: 30d methodology visibility + 14d CLI shipped +
+ * 5+ merge-gate pilot reference accounts + incident-response process
+ * documented. Until that gate exits, this module emits previews only.
+ *
+ * Each check returns a result object:
+ *   { id, status: 'pass' | 'fail' | 'skip' | 'error', detail, evidence }
+ * - `status` drives the preview report's pass/fail headline.
+ * - `detail` is human-readable (one line for the table).
+ * - `evidence` is structured data captured for the would-be attestation.
+ *
+ * Re-runnability: every check operates on the resolved repo at HEAD (or
+ * a caller-provided commit SHA). The check inputs are deterministic so
+ * the output bytes for a given commit should be byte-stable across
+ * machines, modulo the timestamp.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync, spawn } = require('child_process');
+
+const METHODOLOGY_URL = 'https://delimit.ai/methodology/mcp-attestation';
+const METHODOLOGY_VERSION = 'v1';
+
+function _resolveCommit(repoDir) {
+    try {
+        return execSync('git rev-parse HEAD', {
+            cwd: repoDir, encoding: 'utf-8', timeout: 3000,
+        }).trim();
+    } catch {
+        return null;
+    }
+}
+
+function _readJsonSafe(p) {
+    try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch { return null; }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Check 1: dependency-security
+// ────────────────────────────────────────────────────────────────────
+function checkDependencySecurity(repoDir) {
+    const id = 'dependency-security';
+    const pkgPath = path.join(repoDir, 'package.json');
+    if (!fs.existsSync(pkgPath)) {
+        return {
+            id, status: 'skip',
+            detail: 'no package.json — non-Node project (Python/Go/Rust attest paths land in v2)',
+            evidence: { reason: 'package_json_absent' },
+        };
+    }
+    let auditResult;
+    try {
+        const out = execSync('npm audit --json --omit=dev', {
+            cwd: repoDir, encoding: 'utf-8', timeout: 30000,
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        auditResult = JSON.parse(out);
+    } catch (e) {
+        // npm audit exits non-zero when vulns found — output is on stdout.
+        try { auditResult = JSON.parse(e.stdout); } catch { auditResult = null; }
+    }
+    if (!auditResult || !auditResult.metadata) {
+        return {
+            id, status: 'error',
+            detail: 'npm audit unavailable (no lockfile or registry unreachable)',
+            evidence: { reason: 'npm_audit_failed' },
+        };
+    }
+    const vulns = auditResult.metadata.vulnerabilities || {};
+    const critical = vulns.critical || 0;
+    const high = vulns.high || 0;
+    const status = critical > 0 ? 'fail' : 'pass';
+    return {
+        id, status,
+        detail: `npm audit: ${critical} critical, ${high} high, ${vulns.moderate || 0} moderate, ${vulns.low || 0} low`,
+        evidence: {
+            counts: vulns,
+            audit_source: 'npm-audit',
+        },
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Check 2: sbom-presence
+// ────────────────────────────────────────────────────────────────────
+function checkSbomPresence(repoDir) {
+    const id = 'sbom-presence';
+    const candidates = [
+        'sbom.json', 'sbom.cdx.json', 'sbom.spdx.json',
+        '.sbom/cyclonedx.json', '.sbom/spdx.json',
+        'cyclonedx.json', 'spdx.json',
+    ];
+    for (const rel of candidates) {
+        const p = path.join(repoDir, rel);
+        if (fs.existsSync(p)) {
+            const parsed = _readJsonSafe(p);
+            if (!parsed) {
+                return {
+                    id, status: 'fail',
+                    detail: `${rel} present but unparseable JSON`,
+                    evidence: { path: rel, parseable: false },
+                };
+            }
+            const format =
+                parsed.bomFormat ? 'CycloneDX' :
+                parsed.spdxVersion ? 'SPDX' :
+                'unknown';
+            return {
+                id, status: 'pass',
+                detail: `${rel} (${format})`,
+                evidence: { path: rel, format, parseable: true },
+            };
+        }
+    }
+    return {
+        id, status: 'skip',
+        detail: 'no SBOM file found — see methodology for accepted paths',
+        evidence: { searched: candidates },
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Check 3: signed-tag
+// ────────────────────────────────────────────────────────────────────
+function checkSignedTag(repoDir) {
+    const id = 'signed-tag';
+    let tag;
+    try {
+        tag = execSync('git describe --tags --exact-match HEAD', {
+            cwd: repoDir, encoding: 'utf-8', timeout: 3000,
+            stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+    } catch {
+        return {
+            id, status: 'skip',
+            detail: 'HEAD is not on a tagged commit (signed-tag check is release-only)',
+            evidence: { reason: 'no_exact_tag' },
+        };
+    }
+    let verifyOut;
+    try {
+        verifyOut = execSync(`git verify-tag --raw ${tag}`, {
+            cwd: repoDir, encoding: 'utf-8', timeout: 5000,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+    } catch {
+        return {
+            id, status: 'skip',
+            detail: `tag ${tag} present but unsigned (sigstore/git-tag signature absent — not a failure, just recorded)`,
+            evidence: { tag, signed: false },
+        };
+    }
+    return {
+        id, status: 'pass',
+        detail: `tag ${tag} signed`,
+        evidence: { tag, signed: true, verify_output: verifyOut.trim().slice(0, 200) },
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Check 4: mcp-protocol-conformance (live probe — STR-656 Q1)
+// ────────────────────────────────────────────────────────────────────
+//
+// The probe boots the server's declared entry point in a child process,
+// completes the MCP initialize handshake, and calls tools/list over
+// stdio. The captured tool signatures are evidence input for any future
+// signed attestation; signature drift across attested versions is the
+// next-attestation comparison input.
+//
+// Sandbox posture (best-effort, not a hard isolation boundary): empty
+// HOME, restricted PATH, no extra env, hard timeout, SIGKILL on cleanup.
+// The local preview is for surfacing shape; the hosted attestation will
+// run inside a stronger sandbox.
+//
+function _findMcpEntry(pkg) {
+    // Priority order:
+    //   1. pkg.mcp.command (free-form shell string — explicit opt-in)
+    //   2. pkg.mcp.entry   (path to a node script)
+    //   3. pkg.bin (string)  → node <pkg.bin>
+    //   4. pkg.bin (object)  → node <first value>
+    //   5. pkg.main          → node <pkg.main>
+    if (pkg.mcp && typeof pkg.mcp.command === 'string') {
+        return { kind: 'shell', value: pkg.mcp.command };
+    }
+    if (pkg.mcp && typeof pkg.mcp.entry === 'string') {
+        return { kind: 'node', value: pkg.mcp.entry };
+    }
+    if (typeof pkg.bin === 'string') {
+        return { kind: 'node', value: pkg.bin };
+    }
+    if (pkg.bin && typeof pkg.bin === 'object') {
+        const first = Object.values(pkg.bin)[0];
+        if (typeof first === 'string') return { kind: 'node', value: first };
+    }
+    if (typeof pkg.main === 'string') {
+        return { kind: 'node', value: pkg.main };
+    }
+    return null;
+}
+
+function _probeMcpServer(repoDir, entry, timeoutMs) {
+    return new Promise((resolve) => {
+        const cmd = entry.kind === 'shell' ? '/bin/sh' : process.execPath;
+        const args = entry.kind === 'shell' ? ['-c', entry.value] : [entry.value];
+        let proc;
+        try {
+            proc = spawn(cmd, args, {
+                cwd: repoDir,
+                stdio: ['pipe', 'pipe', 'pipe'],
+                env: {
+                    PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin',
+                    NODE_NO_WARNINGS: '1',
+                    DELIMIT_ATTEST_PROBE: '1',
+                },
+            });
+        } catch (e) {
+            return resolve({ ok: false, reason: 'spawn_failed', error: e.message });
+        }
+        const stdoutBuf = [];
+        const stderrBuf = [];
+        let resolved = false;
+        const finish = (result) => {
+            if (resolved) return;
+            resolved = true;
+            try { proc.kill('SIGTERM'); } catch {}
+            setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, 500).unref();
+            resolve(result);
+        };
+        const timer = setTimeout(() => {
+            finish({
+                ok: false, reason: 'timeout',
+                stderr_tail: stderrBuf.join('').slice(-500),
+            });
+        }, timeoutMs);
+        timer.unref();
+        proc.stdout.on('data', (chunk) => {
+            stdoutBuf.push(chunk.toString());
+            const combined = stdoutBuf.join('');
+            for (const line of combined.split('\n')) {
+                if (!line.trim()) continue;
+                try {
+                    const msg = JSON.parse(line);
+                    if (msg.id === 2 && msg.result && Array.isArray(msg.result.tools)) {
+                        clearTimeout(timer);
+                        return finish({ ok: true, tools: msg.result.tools });
+                    }
+                    if (msg.id === 2 && msg.error) {
+                        clearTimeout(timer);
+                        return finish({ ok: false, reason: 'tools_list_error', mcp_error: msg.error });
+                    }
+                } catch { /* incomplete line, keep buffering */ }
+            }
+        });
+        proc.stderr.on('data', (chunk) => { stderrBuf.push(chunk.toString()); });
+        proc.on('error', (e) => {
+            clearTimeout(timer);
+            finish({ ok: false, reason: 'process_error', error: e.message });
+        });
+        proc.on('exit', (code) => {
+            clearTimeout(timer);
+            finish({
+                ok: false, reason: 'process_exit', code,
+                stderr_tail: stderrBuf.join('').slice(-500),
+            });
+        });
+        const init = JSON.stringify({
+            jsonrpc: '2.0', id: 1, method: 'initialize',
+            params: {
+                protocolVersion: '2024-11-05',
+                capabilities: {},
+                clientInfo: { name: 'delimit-attest', version: '1.0' },
+            },
+        }) + '\n';
+        const initialized = JSON.stringify({
+            jsonrpc: '2.0', method: 'notifications/initialized', params: {},
+        }) + '\n';
+        const listTools = JSON.stringify({
+            jsonrpc: '2.0', id: 2, method: 'tools/list', params: {},
+        }) + '\n';
+        try {
+            proc.stdin.write(init);
+            proc.stdin.write(initialized);
+            proc.stdin.write(listTools);
+        } catch (e) {
+            clearTimeout(timer);
+            finish({ ok: false, reason: 'stdin_write_failed', error: e.message });
+        }
+    });
+}
+
+async function checkMcpProtocolConformance(repoDir) {
+    const id = 'mcp-protocol-conformance';
+    const pkgPath = path.join(repoDir, 'package.json');
+    const pkg = _readJsonSafe(pkgPath);
+    if (!pkg) {
+        return {
+            id, status: 'skip',
+            detail: 'no package.json to enumerate MCP entry point',
+            evidence: { reason: 'package_json_absent' },
+        };
+    }
+    const hasMcpDep =
+        (pkg.dependencies && Object.keys(pkg.dependencies).some(k => k.startsWith('@modelcontextprotocol'))) ||
+        (pkg.devDependencies && Object.keys(pkg.devDependencies).some(k => k.startsWith('@modelcontextprotocol')));
+    if (!hasMcpDep && !pkg.mcp) {
+        return {
+            id, status: 'skip',
+            detail: 'no @modelcontextprotocol/* dep or mcp config block — not an MCP server',
+            evidence: { reason: 'mcp_dependency_absent' },
+        };
+    }
+    const entry = _findMcpEntry(pkg);
+    if (!entry) {
+        return {
+            id, status: 'skip',
+            detail: 'MCP entry point not declared (set pkg.mcp.command, pkg.mcp.entry, or pkg.bin)',
+            evidence: { reason: 'no_entry_point', mcp_dep_detected: hasMcpDep },
+        };
+    }
+    if (entry.kind === 'node') {
+        const abs = path.join(repoDir, entry.value);
+        if (!fs.existsSync(abs)) {
+            return {
+                id, status: 'error',
+                detail: `entry point not found on disk: ${entry.value}`,
+                evidence: { entry, missing: true },
+            };
+        }
+    }
+    const probe = await _probeMcpServer(repoDir, entry, 8000);
+    if (!probe.ok) {
+        return {
+            id, status: 'error',
+            detail: `live probe failed: ${probe.reason}${probe.error ? ' — ' + probe.error : ''}`,
+            evidence: { entry, probe },
+        };
+    }
+    const toolSignatures = probe.tools.map(t => ({
+        name: t.name,
+        description_present: !!t.description,
+        input_schema_keys: t.inputSchema && t.inputSchema.properties
+            ? Object.keys(t.inputSchema.properties).sort()
+            : [],
+    }));
+    return {
+        id, status: 'pass',
+        detail: `live probe: ${probe.tools.length} tools enumerated via tools/list`,
+        evidence: {
+            entry,
+            tool_count: probe.tools.length,
+            tool_signatures: toolSignatures,
+            note: 'Signature drift across attested versions is the next-attestation comparison input.',
+        },
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Check 5: known-cve
+// ────────────────────────────────────────────────────────────────────
+function checkKnownCve(repoDir) {
+    const id = 'known-cve';
+    // npm audit (Check 1) already cross-references GHSA + npm advisory DB,
+    // which together cover most public CVEs for the npm ecosystem. For
+    // v1 the known-cve check piggy-backs on npm audit's advisory feed and
+    // records the advisory IDs — full CVE-database resolution is staged
+    // for the v1.1 release once we have a deterministic offline mirror.
+    const depResult = checkDependencySecurity(repoDir);
+    if (depResult.status === 'skip' || depResult.status === 'error') {
+        return {
+            id, status: 'skip',
+            detail: `cve check requires dependency-security to run (was: ${depResult.status})`,
+            evidence: { upstream: depResult.id },
+        };
+    }
+    const counts = depResult.evidence.counts || {};
+    const total = (counts.critical || 0) + (counts.high || 0) +
+                  (counts.moderate || 0) + (counts.low || 0);
+    const status = (counts.critical || 0) > 0 ? 'fail' : 'pass';
+    return {
+        id, status,
+        detail: `${total} advisory IDs cross-referenced (CVE-database probe lands in v1.1)`,
+        evidence: { advisory_counts: counts, source: 'npm-audit/GHSA' },
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Top-level runner
+// ────────────────────────────────────────────────────────────────────
+
+async function _safeRun(id, fn, repoDir) {
+    // Per-check runtime guard (STR-656 Q6 panel verdict). A single check
+    // throwing — sync or async — must not crash the runner. It must
+    // surface as an `error` status so the report is still complete and
+    // the exit-code tier logic can treat it as a tool error (exit 2),
+    // not a policy fail.
+    try {
+        const result = fn(repoDir);
+        return await Promise.resolve(result);
+    } catch (e) {
+        return {
+            id,
+            status: 'error',
+            detail: `check threw: ${e && e.message ? e.message : 'unknown error'}`,
+            evidence: { reason: 'check_exception', message: e && e.message },
+        };
+    }
+}
+
+async function runAttestMcp(opts = {}) {
+    const repoDir = path.resolve(opts.path || process.cwd());
+    if (!fs.existsSync(repoDir)) {
+        return { error: `path not found: ${repoDir}` };
+    }
+    const commit = _resolveCommit(repoDir);
+    const checks = [
+        await _safeRun('dependency-security', checkDependencySecurity, repoDir),
+        await _safeRun('sbom-presence', checkSbomPresence, repoDir),
+        await _safeRun('signed-tag', checkSignedTag, repoDir),
+        await _safeRun('mcp-protocol-conformance', checkMcpProtocolConformance, repoDir),
+        await _safeRun('known-cve', checkKnownCve, repoDir),
+    ];
+    return {
+        kind: 'mcp_attestation_preview',
+        methodology_version: METHODOLOGY_VERSION,
+        methodology_url: METHODOLOGY_URL,
+        repo: { path: repoDir, commit },
+        checks,
+        timestamp: new Date().toISOString(),
+        signed: false,                       // STR-657 gate: never signed in scaffold.
+        public: false,                       // STR-657 gate: never published.
+        scaffold_notice:
+            'DELIMIT ATTESTATION PREVIEW — NOT A PUBLIC ATTESTATION. ' +
+            'MCP attestation is one surface of the Delimit merge gate product family ' +
+            '(PR review + release attestations ship under the same delimit-cli). ' +
+            'The public signed-attestation surface is gated on the methodology being live ≥30d, ' +
+            'this CLI being shipped ≥14d, and 5+ merge-gate pilot reference accounts. ' +
+            `See ${METHODOLOGY_URL}.`,
+    };
+}
+
+function _statusEmoji(s) {
+    return { pass: 'PASS', fail: 'FAIL', skip: 'SKIP', error: 'ERR ' }[s] || s;
+}
+
+function renderPreview(report) {
+    const lines = [];
+    lines.push('');
+    lines.push('  DELIMIT ATTESTATION PREVIEW — NOT A PUBLIC ATTESTATION');
+    lines.push('');
+    lines.push(`  Methodology: ${report.methodology_url}  (${report.methodology_version})`);
+    lines.push(`  Repo:        ${report.repo.path}`);
+    if (report.repo.commit) {
+        lines.push(`  Commit:      ${report.repo.commit}`);
+    }
+    lines.push(`  Timestamp:   ${report.timestamp}`);
+    lines.push('');
+    lines.push('  Checks:');
+    for (const c of report.checks) {
+        lines.push(`    [${_statusEmoji(c.status)}]  ${c.id.padEnd(30)} ${c.detail || ''}`);
+    }
+    lines.push('');
+    lines.push(`  Signed: ${report.signed ? 'yes' : 'no (preview)'}`);
+    lines.push(`  Public: ${report.public ? 'yes' : 'no (gate locked)'}`);
+    lines.push('');
+    lines.push('  This is a local preview only. To understand exactly what this');
+    lines.push(`  attestation would and would NOT cover, read ${report.methodology_url}.`);
+    lines.push('');
+    return lines.join('\n');
+}
+
+module.exports = {
+    runAttestMcp,
+    renderPreview,
+    METHODOLOGY_URL,
+    METHODOLOGY_VERSION,
+};

--- a/lib/attest-telemetry.js
+++ b/lib/attest-telemetry.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * STR-656 Q5 — minimal telemetry counter for `delimit attest <kind>`.
+ *
+ * What this records (one JSONL line per invocation):
+ *   timestamp, kind, outcome, methodology_version, check_summary
+ *
+ * What this does NOT record:
+ *   - repo path, commit SHA, file contents, dependency names, tool names
+ *   - any user-identifying data
+ *
+ * Records land in ~/.delimit/telemetry/attest-<kind>.jsonl. They are local
+ * by default — this module does NOT phone home. The path is documented so
+ * a future opt-in upload can read the same file without changing the CLI.
+ *
+ * Kill switch: `DELIMIT_NO_TELEMETRY=1` disables all writes. Honored across
+ * the Delimit CLI; this module is one of several call sites.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TELEMETRY_DIR = path.join(os.homedir(), '.delimit', 'telemetry');
+
+function _isDisabled() {
+    const v = process.env.DELIMIT_NO_TELEMETRY;
+    return v === '1' || v === 'true' || v === 'yes';
+}
+
+function recordTelemetry(record) {
+    if (_isDisabled()) return;
+    const line = {
+        ts: new Date().toISOString(),
+        ...record,
+    };
+    try {
+        fs.mkdirSync(TELEMETRY_DIR, { recursive: true });
+        const file = path.join(TELEMETRY_DIR, `attest-${record.kind || 'unknown'}.jsonl`);
+        fs.appendFileSync(file, JSON.stringify(line) + '\n');
+    } catch {
+        // Telemetry must never affect the user's exit code or output.
+        // Swallow all errors (EROFS, EACCES, ENOSPC, etc.) silently.
+    }
+}
+
+module.exports = { recordTelemetry, TELEMETRY_DIR };

--- a/lib/delimit-template.js
+++ b/lib/delimit-template.js
@@ -32,6 +32,19 @@ Unify all AI coding assistants with persistent context, governance, and multi-mo
 
 These rules fire automatically. Call the listed tools without asking permission.
 
+### Operating model — default to dispatch (effective 2026-05-01, 30-day review)
+
+Non-trivial work routes through the swarm/agent layer before in-thread execution.
+
+- **Engineering work** with **≥3 independent parallelizable sub-tasks** OR a sub-task with **isolated write scope and amortizable parallel effort** (own subsystem, own artifact boundary, own tests) → call \`delimit_agent_dispatch\` for the parallel arms; the orchestrator does the sequential glue and integration. Do NOT do the parallel work in-thread.
+- **Foundational decisions** (pricing, naming, public-facing copy framing, doctrine edits, layer-separation calls) → call \`delimit_deliberate\` BEFORE applying. This extends the existing external-PR rule to internal doctrine edits.
+- **Sensing / outreach research** → \`delimit_sense\` or \`delimit_intel_query\` or \`delimit_sensor_github_issue\`, not manual web searches.
+- **Social drafts** → \`delimit_social_generate\` then \`delimit_social_post\`, never hand-drafted (per existing rule).
+
+**Bypass is allowed** when the task is genuinely conversational, sub-5-minute and undecomposable, the founder explicitly directs in-session execution, or no automation/agent surface exists for the task yet. State the bypass reason in one line; founder override is always honored. No per-task approval required for stated bypasses.
+
+**Reversibility**: 30-day review (2026-05-30). Dispatch decisions and bypasses are logged via \`delimit_ledger_add\` for the audit trail. If the rule produces over-dispatch friction or under-dispatch (continued in-thread default), it is adjusted or retired at the review.
+
 ### Session Lifecycle
 - **Session start**: call \`delimit_revive\` + \`delimit_ledger_context\` + \`delimit_gov_health\`
 - **Session end or idle**: call \`delimit_soul_capture\` + \`delimit_session_handoff\`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "!gateway/ai/founding_users.py",
     "!gateway/ai/inbox_daemon.py",
     "!gateway/ai/inbox_daemon_runner.py",
+    "!gateway/ai/self_repair/",
+    "!gateway/ai/self_repair_daemon.py",
     "!gateway/ai/deliberation.py",
     "!gateway/ai/dv_mention_tracker.py",
     "!gateway/ai/sensor_twttr.py",

--- a/tests/attest-mcp.test.js
+++ b/tests/attest-mcp.test.js
@@ -1,0 +1,130 @@
+/**
+ * STR-656 — `delimit attest mcp` panel-verdict behavior locks.
+ *
+ * Covers the items Q1–Q6 from the multi-model deliberation review:
+ *   Q1: live MCP-protocol-conformance probe (tools/list)
+ *   Q2: 3-tier exit codes (0 pass+skip, 1 fail, 2 error)
+ *   Q3: --output, --no-write, EROFS soft-fail
+ *   Q5: telemetry counter + DELIMIT_NO_TELEMETRY kill switch
+ *   Q6: top-level runtime guard (single-check throw doesn't crash runner)
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const CLI = path.join(__dirname, '..', 'bin', 'delimit-cli.js');
+const { runAttestMcp } = require('../lib/attest-mcp');
+
+const SKIP_IN_CI = process.env.CI ? 'requires full CLI stack' : false;
+
+function makeFixture(extraFiles = {}) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-mcp-'));
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+        name: 'attest-fixture', version: '0.0.1',
+        dependencies: { '@modelcontextprotocol/sdk': '1.0.0' },
+        ...extraFiles.pkg,
+    }, null, 2));
+    for (const [rel, content] of Object.entries(extraFiles.files || {})) {
+        const p = path.join(dir, rel);
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        fs.writeFileSync(p, content);
+    }
+    return dir;
+}
+
+describe('attest mcp: 3-tier exit codes (Q2)', () => {
+    it('exits 2 when a check errors (no lockfile → npm audit unavailable)',
+        { skip: SKIP_IN_CI }, () => {
+            const dir = makeFixture();
+            const res = spawnSync('node', [CLI, 'attest', 'mcp', '--path', dir, '--no-write'], {
+                env: { ...process.env, DELIMIT_NO_TELEMETRY: '1' },
+                encoding: 'utf-8',
+            });
+            assert.strictEqual(res.status, 2, 'tool error must elevate to exit 2');
+        });
+
+    it('exits 2 on unknown attestation kind', { skip: SKIP_IN_CI }, () => {
+        const res = spawnSync('node', [CLI, 'attest', 'unknown'], {
+            env: { ...process.env, DELIMIT_NO_TELEMETRY: '1' },
+            encoding: 'utf-8',
+        });
+        assert.strictEqual(res.status, 2);
+    });
+});
+
+describe('attest mcp: --output / --no-write (Q3)', () => {
+    it('--no-write does not create .delimit/attestation-preview.json',
+        { skip: SKIP_IN_CI }, () => {
+            const dir = makeFixture();
+            spawnSync('node', [CLI, 'attest', 'mcp', '--path', dir, '--no-write'], {
+                env: { ...process.env, DELIMIT_NO_TELEMETRY: '1' },
+                encoding: 'utf-8',
+            });
+            assert.strictEqual(
+                fs.existsSync(path.join(dir, '.delimit', 'attestation-preview.json')),
+                false,
+                '--no-write must not write the preview file',
+            );
+        });
+
+    it('--output redirects the preview JSON', { skip: SKIP_IN_CI }, () => {
+        const dir = makeFixture();
+        const out = path.join(dir, 'custom-out.json');
+        spawnSync('node', [CLI, 'attest', 'mcp', '--path', dir, '--output', out], {
+            env: { ...process.env, DELIMIT_NO_TELEMETRY: '1' },
+            encoding: 'utf-8',
+        });
+        assert.ok(fs.existsSync(out), '--output target must be created');
+        const parsed = JSON.parse(fs.readFileSync(out, 'utf-8'));
+        assert.strictEqual(parsed.kind, 'mcp_attestation_preview');
+    });
+});
+
+describe('attest mcp: telemetry kill switch (Q5)', () => {
+    it('DELIMIT_NO_TELEMETRY=1 prevents telemetry writes',
+        { skip: SKIP_IN_CI }, () => {
+            // Use HOME override so we can observe the would-be telemetry file
+            const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-home-'));
+            const dir = makeFixture();
+            spawnSync('node', [CLI, 'attest', 'mcp', '--path', dir, '--no-write'], {
+                env: { ...process.env, HOME: tempHome, DELIMIT_NO_TELEMETRY: '1' },
+                encoding: 'utf-8',
+            });
+            const tel = path.join(tempHome, '.delimit', 'telemetry', 'attest-mcp.jsonl');
+            assert.strictEqual(fs.existsSync(tel), false,
+                'kill switch must prevent the telemetry file from being created');
+        });
+});
+
+describe('attest mcp: runtime guard (Q6)', () => {
+    it('runner returns a complete report even with malformed package.json',
+        async () => {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-bad-'));
+            fs.writeFileSync(path.join(dir, 'package.json'), '{not valid json');
+            const report = await runAttestMcp({ path: dir });
+            assert.ok(report.checks, 'report must include checks even on bad input');
+            assert.strictEqual(report.checks.length, 5, 'all five checks must be represented');
+            for (const c of report.checks) {
+                assert.ok(['pass', 'fail', 'skip', 'error'].includes(c.status),
+                    `check ${c.id} returned invalid status: ${c.status}`);
+            }
+        });
+
+    it('non-existent path returns structured error, not crash', async () => {
+        const report = await runAttestMcp({ path: '/nonexistent/path/here-zzz' });
+        assert.ok(report.error, 'must return error field');
+    });
+});
+
+describe('attest mcp: framing (no separate-product language)', () => {
+    it('scaffold notice references merge gate product family', async () => {
+        const dir = makeFixture();
+        const report = await runAttestMcp({ path: dir });
+        assert.match(report.scaffold_notice, /merge gate product family/i,
+            'scaffold notice must position attest mcp as part of the merge gate, not standalone');
+    });
+});

--- a/tests/attest-mcp.test.js
+++ b/tests/attest-mcp.test.js
@@ -84,6 +84,33 @@ describe('attest mcp: --output / --no-write (Q3)', () => {
     });
 });
 
+describe('attest mcp: --write deprecation (panel verdict pre-push)', () => {
+    it('--write emits a deprecation warning to stderr',
+        { skip: SKIP_IN_CI }, () => {
+            const dir = makeFixture();
+            const out = path.join(dir, 'via-write.json');
+            const res = spawnSync('node', [CLI, 'attest', 'mcp', '--path', dir, '--write', out], {
+                env: { ...process.env, DELIMIT_NO_TELEMETRY: '1', FORCE_COLOR: '0' },
+                encoding: 'utf-8',
+            });
+            assert.match(res.stderr, /\[deprecation\] --write is deprecated/i,
+                '--write must emit a one-line deprecation warning to stderr');
+            assert.ok(fs.existsSync(out), '--write must still write the file');
+        });
+
+    it('--output does NOT emit a deprecation warning',
+        { skip: SKIP_IN_CI }, () => {
+            const dir = makeFixture();
+            const out = path.join(dir, 'via-output.json');
+            const res = spawnSync('node', [CLI, 'attest', 'mcp', '--path', dir, '--output', out], {
+                env: { ...process.env, DELIMIT_NO_TELEMETRY: '1', FORCE_COLOR: '0' },
+                encoding: 'utf-8',
+            });
+            assert.doesNotMatch(res.stderr, /deprecation/i,
+                '--output is the canonical flag and must not warn');
+        });
+});
+
 describe('attest mcp: telemetry kill switch (Q5)', () => {
     it('DELIMIT_NO_TELEMETRY=1 prevents telemetry writes',
         { skip: SKIP_IN_CI }, () => {


### PR DESCRIPTION
## Summary

Two related customer-surface fixes following the 2026-04-30 corp-function-first revision and self-repair panel verdict:

1. **`lib/delimit-template.js`** — sync the new "default to dispatch" operating-model rule into the npm-shipped CLAUDE.md template. New customers running \`delimit setup\` were missing this rule.

2. **\`package.json\`** — exclude self-repair from the npm pack:
   - \`!gateway/ai/self_repair/\` (alert+diagnose+deliberate+apply+verify+history+watcher+cli+configs)
   - \`!gateway/ai/self_repair_daemon.py\` (production daemon wrapper)

Verified via \`npm pack --dry-run\` — no self_repair files in the bundle.

## Why gate self-repair as gateway-only

Founder concern surfaced this turn: customers shouldn't run multiple long-running daemons on their dev machines. Three daemons (inbox + social + self-repair) is fine on Jamsons' gateway server (one place, one config) but a real burden for end users. Per the panel verdict, self-repair stays gateway-private. Customer-facing surface remains:

- \`delimit lint\` / \`delimit attest\` / \`delimit deliberate\` (on-demand)
- \`delimit self-repair check\` (on-demand, exits — already CLI-shipped)
- GitHub Action (CI-driven)

For continuous monitoring, customers wire one cron line:
\`\`\`
0 * * * * delimit self-repair check && delimit self-repair verify
\`\`\`

The \`delimit_self_repair_daemon\` MCP tool stays registered in server.py with lazy import — same gating pattern as \`inbox_daemon\`. Customer's MCP server registers the tool, calling it raises ImportError. Internal-only.

## Test plan
- [x] \`npm pack --dry-run\` — no self_repair files in pack
- [x] Template inserted in correct section (between \`## Auto-Trigger Rules\` and \`### Session Lifecycle\`)
- [ ] Verify in next \`delimit setup\` test that fresh CLAUDE.md includes the dispatch rule
- [ ] Verify in next npm publish that customer's MCP server registers \`delimit_self_repair_daemon\` but the call raises ImportError (existing inbox_daemon parity check)

## Linked
- Operating model deliberation: \`/home/delimit/delimit-private/deliberations/2026-04-30-corp-function-first-operating-model.md\`
- Self-repair deliberation: \`/home/delimit/delimit-private/deliberations/2026-04-30-self-repair-loop.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)