### PR TITLE
template: reframe operating-model rule per swarm-executor verdict

### DIFF
--- a/lib/delimit-template.js
+++ b/lib/delimit-template.js
@@ -32,14 +32,15 @@ Unify all AI coding assistants with persistent context, governance, and multi-mo
 
 These rules fire automatically. Call the listed tools without asking permission.
 
-### Operating model — default to dispatch (effective 2026-05-01, 30-day review)
+### Operating model — default to subagent dispatch (revised 2026-05-01)
 
-Non-trivial work routes through the swarm/agent layer before in-thread execution.
+Non-trivial engineering work routes through in-session subagents, not in-thread execution by the orchestrator.
 
-- **Engineering work** with **≥3 independent parallelizable sub-tasks** OR a sub-task with **isolated write scope and amortizable parallel effort** (own subsystem, own artifact boundary, own tests) → call \`delimit_agent_dispatch\` for the parallel arms; the orchestrator does the sequential glue and integration. Do NOT do the parallel work in-thread.
+- **Engineering work** with **≥3 independent parallelizable sub-tasks** OR a sub-task with **isolated write scope and amortizable parallel effort** (own subsystem, own artifact boundary, own tests) → spawn an engineering subagent (Agent tool, subagent_type=engineering) for the parallel arms; the orchestrator does the sequential glue and integration. Do NOT do the parallel work in-thread.
 - **Foundational decisions** (pricing, naming, public-facing copy framing, doctrine edits, layer-separation calls) → call \`delimit_deliberate\` BEFORE applying. This extends the existing external-PR rule to internal doctrine edits.
 - **Sensing / outreach research** → \`delimit_sense\` or \`delimit_intel_query\` or \`delimit_sensor_github_issue\`, not manual web searches.
 - **Social drafts** → \`delimit_social_generate\` then \`delimit_social_post\`, never hand-drafted (per existing rule).
+- **Audit trail for dispatched work** → \`delimit_agent_dispatch\` records intent + assignee + outcome for replay. It is a **planning + audit surface**, not a queue processor; tasks dispatched here do NOT auto-execute. Real autonomous queue execution is a future capability with strict sandboxing + founder-approval semantics.
 
 **Bypass is allowed** when the task is genuinely conversational, sub-5-minute and undecomposable, the founder explicitly directs in-session execution, or no automation/agent surface exists for the task yet. State the bypass reason in one line; founder override is always honored. No per-task approval required for stated bypasses.
 


### PR DESCRIPTION
## Summary

2026-05-01 swarm-executor panel deliberation (Option C unanimous): \`delimit_agent_dispatch\` is a planning + audit surface, NOT a queue processor. Tasks dispatched there do not auto-execute.

The yesterday \"default to dispatch\" rule that landed in #74 presupposed the dispatch tool had a working executor processing the queue. Today's investigation found the executor is INACTIVE (delimit-agent.service points to a stale path, hasn't been running). Real engineering work has been done by in-session Agent-tool subagents the whole time.

This PR updates the rule to match observed reality:
- Engineering work routes through in-session subagents (Agent tool, subagent_type=engineering)
- \`delimit_agent_dispatch\` records intent + assignee + outcome for replay/audit
- Real autonomous queue execution is deferred to LED-193 (unified \`delimit_daemon\`) with mandatory governance constraints

## Customer impact: zero

The npm package never shipped a working executor (gateway-side only, gated via package.json). Customers see no behavioral regression — only doc accuracy.

## Linked

- Panel transcript: \`/home/delimit/delimit-private/deliberations/2026-05-01-swarm-executor-fix-build-or-reframe.md\`
- LED-193: daemon consolidation + future executor with absorbed governance constraints
- Replaces closed #75 (was conflicting; recreated fresh from current main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)