### PR TITLE
package: gate corp_dashboard as gateway-only (LED-189 follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "!gateway/ai/inbox_daemon_runner.py",
     "!gateway/ai/self_repair/",
     "!gateway/ai/self_repair_daemon.py",
+    "!gateway/ai/corp_dashboard.py",
     "!gateway/ai/deliberation.py",
     "!gateway/ai/dv_mention_tracker.py",
     "!gateway/ai/sensor_twttr.py",


### PR DESCRIPTION
## Summary

LED-189 \`delimit_corp_dashboard\` shipped to delimit-gateway/main (delimit-gateway#100). The corp-status synthesizer is internal/operational tooling — same gating posture as inbox_daemon, social_daemon, self_repair_daemon, self_repair/.

Adds \`!gateway/ai/corp_dashboard.py\` to the npm pack exclusion list.

## Why

Customer's MCP server registers the tool (server.py exposes it) but calling it raises ImportError because the underlying module is excluded from the package — same lazy-import gating pattern as the other internal-only tools. Operational tooling stays gateway-side; customer-facing surface stays narrow.

## Verified

\`npm pack --dry-run\` confirms \`gateway/ai/corp_dashboard.py\` is not in the bundle. 171/171 npm tests pass on the branch.

## Test plan
- [x] \`npm pack --dry-run\` clean
- [x] Pre-push gate green (171/171)

🤖 Generated with [Claude Code](https://claude.com/claude-code)