### PR TITLE
fix(deps): bump axios 1.16.0 + follow-redirects (LED-1249) — 4.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "delimit-cli",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "delimit-cli",
-      "version": "4.5.2",
+      "version": "4.5.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "1.15.0",
+        "axios": "^1.16.0",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "express": "^4.18.0",
@@ -134,12 +134,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [
@@ -111,7 +111,7 @@
     "url": "https://github.com/delimit-ai/delimit-mcp-server.git"
   },
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "^1.16.0",
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "express": "^4.18.0",


### PR DESCRIPTION
## Summary

- **Patch release with security dep bumps.** Bumps axios 1.15.0 → 1.16.0 + follow-redirects (transitive) via package.json + package-lock.json only. No source code changes.
- **Clears 12+ axios CVEs** including prototype pollution, CRLF injection, SSRF (NO_PROXY bypass via 127.0.0.0/8), header injection, XSRF leakage, null byte injection, unbounded recursion DoS, maxBodyLength + maxContentLength bypass, JSON parseReviver tampering.
- **Final `npm audit` reports 0 vulnerabilities.**
- Deferred from LED-1246 panel verdict (separated from JAMSONS security fix to keep that release scope tight).

## Test plan

- [x] `npm install axios@1.16.0` clean
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] `npm test` → 142/142 pass, 54 skipped, exit 0

## Customer impact

- No CLI command, MCP tool, or storage format changes
- Backwards compatible
- Customers get fix via `npm update -g delimit-cli` or next `delimit-cli setup`

## Linked items

- `LED-1249` (P1 — this release)
- `LED-1246` (P0 — JAMSONS fix shipped in 4.5.3, this is the deferred follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)