### PR TITLE
fix(hooks): 3-tier fallback for delimit setup hooks (LED-1248) — 4.5.5

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -4629,18 +4629,33 @@ program
         const prePushPath = path.join(hooksDir, 'pre-push');
         const marker = '# delimit-governance-hook';
 
+        // Resolution order: local node_modules → global PATH → npx fallback.
+        // npx is last because it can fail with Arborist 'extraneous' errors
+        // when a project's node_modules / lockfile drift (LED-1248).
         const preCommitHook = `#!/bin/sh
 ${marker}
 # Delimit API governance gate
 # Blocks commits with breaking API changes
-npx delimit-cli check --staged
+if [ -x ./node_modules/.bin/delimit-cli ]; then
+  ./node_modules/.bin/delimit-cli check --staged
+elif command -v delimit-cli >/dev/null 2>&1; then
+  delimit-cli check --staged
+else
+  npx delimit-cli check --staged
+fi
 `;
 
         const prePushHook = `#!/bin/sh
 ${marker}
 # Delimit API governance gate
 # Blocks pushes with breaking API changes
-npx delimit-cli check --base origin/main
+if [ -x ./node_modules/.bin/delimit-cli ]; then
+  ./node_modules/.bin/delimit-cli check --base origin/main
+elif command -v delimit-cli >/dev/null 2>&1; then
+  delimit-cli check --base origin/main
+else
+  npx delimit-cli check --base origin/main
+fi
 `;
 
         if (action === 'install') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary

- **Bug fix.** The pre-commit + pre-push hooks installed by `delimit setup hooks` (and post-install) hardcoded `npx delimit-cli check ...`, which fails on `Cannot read properties of undefined (reading 'extraneous')` from npm Arborist when a project's `node_modules` / lockfile drift.
- Surfaced during 4.5.3 release work — local hook had to be patched manually before commit could proceed (LED-1248).
- Replaces with 3-tier resolution: project-local `node_modules/.bin/delimit-cli` → global PATH → `npx` (last resort).
- Most installations have local or global delimit-cli; broken `npx` path is now reached only as fallback.

## Test plan

- [x] `npm test` — 142/142 pass, 54 skipped, exit 0
- [x] Hook-content edit verified visually in `bin/delimit-cli.js:4632-4660`

## Customer impact

- Existing customers' previously-installed hooks aren't touched — they still use `npx`. To pick up the fix they re-run `delimit setup hooks` after upgrading to 4.5.5.
- New `delimit setup hooks` runs (or fresh installs) get the 3-tier fallback.
- No breaking changes; backwards compatible.

## Linked items

- `LED-1248` (P2 — this fix)
- `LED-1246` (P0, 4.5.3 — surfaced this issue during release work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)