### PR TITLE
fix(security): remove DELIMIT_TEST_MODE bypass (LED-1254, P0) — 4.5.6

### DIFF
--- a/gateway/ai/governance.py
+++ b/gateway/ai/governance.py
@@ -18,19 +18,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-def _is_test_mode() -> bool:
-    """Return True when DELIMIT_TEST_MODE is explicitly set.
-
-    When True the governance loop skips real ledger writes to avoid
-    polluting the project ledger with mock/test data.
-
-    We intentionally do NOT auto-detect PYTEST_CURRENT_TEST here
-    because the gateway's own test suite mocks ledger calls and needs
-    governance to attempt those calls so assertions work.  Set
-    DELIMIT_TEST_MODE=1 in external test harnesses that trigger
-    governance but do not mock the ledger.
-    """
-    return bool(os.environ.get("DELIMIT_TEST_MODE"))
+# LED-1254 (P0 SECURITY): the previous _is_test_mode() helper read the
+# DELIMIT_TEST_MODE env var to skip real ledger writes. That env var was a
+# customer-visible bypass surface (grep-discoverable in shipped source).
+# The shim has been removed; tests must mock ai.governance._ledger_add_item
+# directly (see tests/conftest.py and test_governance.py for the pattern).
 
 logger = logging.getLogger("delimit.governance")
 
@@ -755,16 +747,9 @@ def govern(tool_name: str, result: Dict[str, Any], project_path: str = ".") -> D
                 if isinstance(i, dict) and i.get("status") == "open"
             }
             created = []
-            test_mode = _is_test_mode()
             for item in auto_items:
                 if item["title"] in open_titles:
                     logger.debug("Skipping duplicate ledger item: %s", item["title"])
-                    continue
-                if test_mode:
-                    # In test mode, skip real ledger writes to avoid
-                    # polluting the project ledger with mock/test data.
-                    logger.debug("Test mode: skipping ledger write for %s", item["title"])
-                    created.append(f"TEST-{item['title'][:40]}")
                     continue
                 entry = _ledger_add_item(
                     title=item["title"],

--- a/gateway/ai/license.py
+++ b/gateway/ai/license.py
@@ -231,28 +231,10 @@ except ImportError:
         LICENSE_FILE.write_text(json.dumps(license_data, indent=2))
         return {"status": "activated", "tier": "pro", "message": "Activated (offline fallback). Will validate on next network access."}
 
-
-# ─── LED-2060 (P1): test-mode license bypass ─────────────────────────────
-# tests/conftest.py sets DELIMIT_TEST_MODE=1 at session start. Without this
-# wrapper, every test that exercises a Pro tool got back a premium_required
-# error and asserted-against-the-wrong-shape, blocking CI on every PR.
-# Bypass is scoped: only active when the env var is explicitly set, only
-# returns None (the "no gate" sentinel), and wraps both compiled-binary
-# and fallback paths. Customers never hit this path because their
-# environments don't set DELIMIT_TEST_MODE.
-import os as _os
-
-_original_require_premium = require_premium  # type: ignore[has-type]
-_original_is_premium = is_premium  # type: ignore[has-type]
-
-
-def require_premium(tool_name: str):  # type: ignore[no-redef]
-    if _os.environ.get("DELIMIT_TEST_MODE") == "1":
-        return None
-    return _original_require_premium(tool_name)
-
-
-def is_premium() -> bool:  # type: ignore[no-redef]
-    if _os.environ.get("DELIMIT_TEST_MODE") == "1":
-        return True
-    return _original_is_premium()
+# ─── LED-1254 (P0 SECURITY) ──────────────────────────────────────────────
+# The DELIMIT_TEST_MODE bypass that previously lived here was removed:
+# it allowed any user who grepped the installed source to set
+# DELIMIT_TEST_MODE=1 and unconditionally bypass every Pro license check.
+# Test-time bypass is now provided exclusively by tests/conftest.py via
+# monkeypatch on require_premium / is_premium. The shipped library no
+# longer reads any test-mode env var.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary

**P0 SECURITY** — removes the second license-bypass leak surfaced by the 2026-05-07 inventory subagent (C1 CRITICAL). Same exploitability class as the prefix-based license bypass fixed in LED-1246: any customer who greps their local install at \`~/.delimit/server/gateway/ai/license.py\` could see the \`DELIMIT_TEST_MODE\` env var name and set it to bypass every Pro license check.

Closes LED-1254.

## What changed

- \`gateway/ai/license.py\`: removed lines 235-258 (DELIMIT_TEST_MODE bypass wrappers + import os as _os)
- \`gateway/ai/governance.py\`: removed \`_is_test_mode()\` function and its single caller branch (now writes ledger unconditionally)
- \`package.json\`: 4.5.5 → 4.5.6 (security patch)
- \`tests/conftest.py\` + \`tests/test_license.py\` + \`tests/test_activate_checklist.py\`: test-mode behavior moved to monkeypatch fixtures (gateway repo — separate PR)

## Test plan

- [x] Targeted license + premium-gate tests: **111 pass, 69 skipped, 0 fail**
- [x] Full smoke (excluding pre-existing flaky test_content_engine per LED-1251): **4343 pass, 9 pre-existing failures** (5 deliberation env, 2 zero_spec extractor, 2 flaky)
- [x] Verified shipped tarball via \`npm pack --dry-run\` extraction: **zero exploitable DELIMIT_TEST_MODE matches** in delimit-cli-4.5.6.tgz. Remaining string matches are notify.py quarantine filter (defensive — detects leaks) and a remediation comment.

## Customer impact

- Customers running 4.5.5 currently have the DELIMIT_TEST_MODE bypass in their local install. Upgrading to 4.5.6 removes it.
- No CLI command, MCP tool param, or storage format changes. Backwards compatible.

## Out of scope (filed as follow-ups)

- \`LED-1262\` (P1): \`social.py\` + \`deliberation.py\` have the same DELIMIT_TEST_MODE pattern but those files are PROPRIETARY (excluded from npm bundle), so not a customer-facing exploit. Cleanup for consistency only.
- \`LED-1255\` (P0): same-shape evaluation of DELIMIT_INTERNAL_LICENSE_KEY (the bypass I introduced in LED-1246) — separate decision needed on whether to remove or move to build-time.
- \`LED-1256\` (P0): DELIMIT_INTERNAL_BRIDGE_TOKEN published default \"delimit-internal-bridge\" — separate audit needed.
- \`LED-1257\` (P1): the-holdco identity scrub in gateway/core/*.py + CHANGELOG.md.

## Linked items

- \`LED-1254\` (P0 — this PR)
- \`LED-1246\` (P0, 4.5.3 — first license-bypass fix; this is the sequel from the same inventory finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)