### PR TITLE
fix(security): remove env-var-driven license bypass (LED-1255, P0) — 4.5.7

### DIFF
--- a/gateway/ai/license.py
+++ b/gateway/ai/license.py
@@ -116,8 +116,7 @@ except ImportError:
         import hashlib
         import urllib.request
         key = data.get("key", "")
-        _internal = os.environ.get("DELIMIT_INTERNAL_LICENSE_KEY", "")
-        if not key or (_internal and key == _internal):
+        if not key:
             data["last_validated_at"] = time.time()
             data["validation_status"] = "current"
             _write_license(data)
@@ -172,10 +171,6 @@ except ImportError:
             return False
         if not data.get("valid", False):
             return False
-        key = data.get("key", "")
-        _internal = os.environ.get("DELIMIT_INTERNAL_LICENSE_KEY", "")
-        if _internal and key == _internal:
-            return True
         last_validated = data.get("last_validated_at", data.get("activated_at", 0))
         if last_validated == 0:
             return True

--- a/gateway/ai/license_core.py
+++ b/gateway/ai/license_core.py
@@ -86,9 +86,8 @@ def revalidate_license(data: dict) -> dict:
         Also includes 'updated_data' with the (possibly modified) license data.
     """
     key = data.get("key", "")
-    # Empty key (dev environments) or internal license override (env-var-driven)
-    _internal = os.environ.get("DELIMIT_INTERNAL_LICENSE_KEY", "")
-    if not key or (_internal and key == _internal):
+    # Empty key passes (dev environments without a license file)
+    if not key:
         data["last_validated_at"] = time.time()
         data["validation_status"] = "current"
         _write_license(data)
@@ -152,11 +151,6 @@ def is_license_valid(data: dict) -> bool:
         return False
     if not data.get("valid", False):
         return False
-    # Internal license override (env-var-driven; empty for customers)
-    key = data.get("key", "")
-    _internal = os.environ.get("DELIMIT_INTERNAL_LICENSE_KEY", "")
-    if _internal and key == _internal:
-        return True
     last_validated = data.get("last_validated_at", data.get("activated_at", 0))
     if last_validated == 0:
         return True  # Legacy — allow access but needs_revalidation will trigger check

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary

**P0 SECURITY** — third bypass removal in tonight's series. Removes the env-var-driven license bypass (`DELIMIT_INTERNAL_LICENSE_KEY` check) from `gateway/ai/license_core.py` + `gateway/ai/license.py`. Less exploitable than LED-1246/LED-1254 (customer would need to know the internal key value, not just the env var name) but still a hidden privileged mode disclosed in shipped source.

Per LED-1255 panel verdict: option (a) — remove entirely. No replacement mechanism in shipped code. Founder dev box uses a real Pro license key + the existing timestamp-based validation path; no backdoor surface remaining.

Closes LED-1255.

## What changed

- `gateway/ai/license_core.py`: removed env-var read in `revalidate_license()` and `is_license_valid()`. Empty-key dev-environment check preserved.
- `gateway/ai/license.py`: same removal in fallback definitions inside `except ImportError` block.
- `package.json`: `4.5.6` → `4.5.7` (security patch).
- (Gateway repo separately: `tests/test_license.py` rewired — 3 bypass-specific tests deleted, 1 rewritten to use strict-format key + timestamp-zero path.)

## Test plan

- [x] Targeted: 110/110 license + premium-gate tests pass (was 111; lost 1 net after deletion + 1 new test added in another LED)
- [x] Full smoke: 4340 pass, 9 pre-existing failures (deliberation env, zero_spec extractor, flaky — all unrelated)
- [x] `grep -rn DELIMIT_INTERNAL_LICENSE_KEY` against shipped paths: **0 matches**
- [x] `npm pack --dry-run` extracted tarball: **0 matches**

## Customer impact

- Customers running 4.5.6 pick up the removal via `npm update -g delimit-cli`. Their existing license validation flow (Lemon Squeezy revalidation within 30-44 days) is unchanged.
- Founder dev environments using the previous env-var bypass: switch to a real Pro license key OR rely on the standard timestamp grace period (44 days from last validation).
- No CLI command, MCP tool param, or storage format changes. Backwards compatible.

## Closes the bypass series (3 of 3 customer-facing)

| Release | LED | Bypass class removed |
|---|---|---|
| 4.5.3 | LED-1246 | Hardcoded prefix (compile-time string) |
| 4.5.6 | LED-1254 | Env-var-driven test mode |
| **4.5.7** | **LED-1255** | **Env-var-driven internal key** |

`LED-1262` (P1, follow-up) remains: same env-var pattern in proprietary `social.py` + `deliberation.py` files, but those don't ship to customers (proprietary-gating excludes them from the npm bundle), so customer-facing surface is now bypass-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)