### PR TITLE
fix(orphan-tools): graceful fail-message for inbox_daemon + social_daemon (LED-1261) — 4.5.10

### DIFF
--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -7618,7 +7618,15 @@ def delimit_inbox_daemon(action: str = "status") -> Dict[str, Any]:
         action: 'start' (begin polling), 'stop' (halt polling),
                 'status' (show daemon state, last poll, failures).
     """
-    from ai.inbox_daemon import start_daemon, stop_daemon, get_daemon_status
+    try:
+        from ai.inbox_daemon import start_daemon, stop_daemon, get_daemon_status
+    except (ImportError, ModuleNotFoundError):
+        # LED-1261: backing module is gateway-only (excluded from npm bundle).
+        return _with_next_steps("inbox_daemon", {
+            "status": "not_available",
+            "error": "delimit_inbox_daemon is an internal Delimit feature not shipped in the npm bundle.",
+            "hint": "Pro customers interested in inbox automation can contact pro@delimit.ai.",
+        })
 
     if action == "start":
         return _with_next_steps("inbox_daemon", start_daemon())
@@ -7639,7 +7647,15 @@ def delimit_social_daemon(action: str = "status") -> Dict[str, Any]:
         action: 'start' (begin scanning), 'stop' (halt scanning),
                 'status' (show daemon state, last scan, targets found).
     """
-    from ai.social_daemon import start_daemon, stop_daemon, get_daemon_status
+    try:
+        from ai.social_daemon import start_daemon, stop_daemon, get_daemon_status
+    except (ImportError, ModuleNotFoundError):
+        # LED-1261: backing module is gateway-only (excluded from npm bundle).
+        return _with_next_steps("social_daemon", {
+            "status": "not_available",
+            "error": "delimit_social_daemon is an internal Delimit feature not shipped in the npm bundle.",
+            "hint": "Pro customers interested in social automation can contact pro@delimit.ai.",
+        })
 
     if action == "start":
         return _with_next_steps("social_daemon", start_daemon())

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.5.9",
+  "version": "4.5.10",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Surgical version (replaces closed PR #87 which over-mirrored). Wraps the 2 customer-visible orphan-tool imports with try/except for a graceful not_available message instead of raw ModuleNotFoundError. Diff is now small + scoped. Closes LED-1261 npm-delimit side.