### PR TITLE
fix(ci): install Nuitka before LED-1259 compile steps — 4.5.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Install Nuitka (LED-1259 compile)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'nuitka==2.5.9'
+
       - name: Test license_core .so (LED-1259)
         working-directory: npm-delimit
         run: bash scripts/test-license-core-so.sh
@@ -146,6 +151,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+
+      - name: Install Nuitka (LED-1259 compile)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'nuitka==2.5.9'
 
       - name: Compile license_core to native .so (LED-1259)
         working-directory: npm-delimit

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.5.11",
+  "version": "4.5.12",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Summary

- The v4.5.11 publish workflow halted at the new `Test license_core .so (LED-1259)` step with `No module named nuitka` — neither the test step nor the workflow installs nuitka before invoking it. (build-license-core.sh self-bootstraps but never runs because the test step fails first.)
- Adds an explicit `Install Nuitka` step in both validate and publish jobs after Python setup, pinned to `nuitka==2.5.9` (matches local dev POC).
- Bumps to 4.5.12 rather than retagging v4.5.11. The v4.5.11 publish never reached npm so no shipped artifact is affected, but version numbers are not re-used per release discipline.

## CI failure quote

```
🧪 test-license-core-so: building in /tmp/tmp.IYArs7YMOy
/opt/hostedtoolcache/Python/3.10.20/x64/bin/python3: No module named nuitka
##[error]Process completed with exit code 1.
```
(run 25561901680, job 75035389651)

## Test plan

- [x] Local: `python3 -m nuitka --version` → `2.5.9` ✓ (matches pin)
- [ ] CI: validate job clears `Test license_core .so` and `Compile` steps
- [ ] CI: publish job's `Compile` step succeeds with same nuitka install
- [ ] npm registry shows `delimit-cli@4.5.12` after merge + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)