### PR TITLE
fix(publish): compile license_core .so AFTER sync-gateway — 4.5.13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,13 +153,12 @@ jobs:
           python-version: '3.10'
 
       - name: Install Nuitka (LED-1259 compile)
+        # prepublishOnly runs sync-gateway then build-license-core.sh so the
+        # .so is generated AFTER rsync and is the artifact npm pack picks up.
+        # nuitka must be importable when prepublishOnly fires.
         run: |
           python -m pip install --upgrade pip
           python -m pip install 'nuitka==2.5.9'
-
-      - name: Compile license_core to native .so (LED-1259)
-        working-directory: npm-delimit
-        run: bash scripts/build-license-core.sh
 
       - name: Publish (dry run)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.5.12",
+  "version": "4.5.13",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [
@@ -55,7 +55,7 @@
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
     "sync-gateway": "bash scripts/sync-gateway.sh",
-    "prepublishOnly": "bash scripts/publish-ci-guard.sh && npm run sync-gateway && bash scripts/security-check.sh",
+    "prepublishOnly": "bash scripts/publish-ci-guard.sh && npm run sync-gateway && bash scripts/build-license-core.sh && bash scripts/security-check.sh",
     "test": "node --test tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- v4.5.12 shipped a **broken** `.so`-less tarball — `prepublishOnly` re-runs `sync-gateway`, which uses `rsync -a --delete` and wipes the freshly-compiled `license_core.cpython-*.so` out of the bundle right before `npm pack`. Customers on 4.5.12 silently fall back to the Python `license_core` (defeating LED-1259).
- Fix: chain `build-license-core.sh` into `prepublishOnly` AFTER `sync-gateway`. Now the .so is generated last and is what `npm pack` picks up. Works the same in CI and local publish.
- Drop the redundant explicit `Compile` step from the publish job.

## Customer-impact note (4.5.12)

4.5.12 is on npm and broken. Pro features that depend on the compiled `license_core` will fall through the `except ImportError` branch in `gateway/ai/license.py` and print the fallback warning to stderr. License validation still works (the Python fallback is intact) — this is functional regression, not a security regression. 4.5.13 fixes it; recommend customers upgrade.

## Local rehearsal evidence

```
$ npm run prepublishOnly
🔄 Syncing gateway → npm bundle... ✅ ai/: 131 files
🔧 build-license-core: python=python3 (3.10), arch=x86_64
   ✅ produced: license_core.cpython-310-x86_64-linux-gnu.so (372456 bytes)
   ✅ strings-grep clean (no bypass identifiers)
   ✅ removed plaintext license_core.py from bundle

$ npm pack --dry-run | grep license_core
372.5kB gateway/ai/license_core.cpython-310-x86_64-linux-gnu.so
2.0kB   gateway/ai/license_core.pyi
```

## Test plan

- [x] Local: prepublishOnly produces .so + npm pack shows it
- [ ] CI: validate job clears (test step still runs against gateway src)
- [ ] CI: publish job's prepublishOnly chain produces + ships .so
- [ ] Verify published 4.5.13 tarball contains `license_core.cpython-*.so`

🤖 Generated with [Claude Code](https://claude.com/claude-code)