### PR TITLE
feat(cli): delimit signin — OAuth bearer token capture for hosted deliberation

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -69,7 +69,7 @@ function normalizeNaturalLanguageArgs(argv) {
     const explicitCommands = new Set([
         'install', 'mode', 'status', 'session', 'build', 'ask', 'policy', 'auth', 'audit',
         'explain-decision', 'uninstall', 'proxy', 'hook', 'version', 'vault', 'deliberate',
-        'remember', 'recall', 'forget', 'report'
+        'remember', 'recall', 'forget', 'report', 'signin', 'activate'
     ]);
     if (explicitCommands.has((raw[0] || '').toLowerCase())) {
         return raw;
@@ -5651,6 +5651,98 @@ program
                 activated_at: new Date().toISOString(),
             }, { timeout: 5000 }).catch(() => {});
         } catch {}
+    });
+
+// ---------------------------------------------------------------------------
+// LED-2100: `delimit signin` — capture delimit.ai OAuth bearer token so the
+// hosted-deliberation tier (LED-2092) can authenticate from the CLI. The
+// token is written to ~/.delimit/auth.json (mode 0600) where the gateway
+// reads it via deliberation.py::_read_oauth_token. Existing keys in
+// auth.json (e.g. from `delimit auth`) are preserved.
+//
+// Surface contract (do not change without coordinating with the gateway):
+//   - Writes `delimit_token` and `access_token` (same value, dual-key for
+//     compatibility with the gateway resolver's preferred-then-fallback read)
+//   - Writes `signed_in_at` (ISO8601) and `email` (when supplied)
+//   - Distinct from `delimit activate <key>` which writes license.json for
+//     the Pro license-key flow. Sign-in is OAuth-bearer-token only.
+//
+// Default flow is paste-token (works in headless / SSH sessions). The
+// browser-callback flow is a follow-up once delimit.ai/account/cli ships
+// the cli-aware redirect endpoint.
+// ---------------------------------------------------------------------------
+program
+    .command('signin')
+    .description('Sign in to delimit.ai to enable hosted multi-model deliberation')
+    .option('--token <token>', 'Provide the bearer token directly (skip prompt)')
+    .option('--email <email>', 'Associate the token with an email address')
+    .option('--status', 'Print current sign-in status without changes')
+    .action(async (options) => {
+        const { writeAuthToken, readCurrentToken, authFilePath } = require('../lib/auth-signin');
+
+        if (options.status) {
+            const token = readCurrentToken();
+            if (!token) {
+                console.log(chalk.yellow('  Not signed in.'));
+                console.log(chalk.dim(`  Run: delimit signin`));
+                process.exit(1);
+            }
+            console.log(chalk.green('  Signed in.'));
+            console.log(chalk.dim(`  Auth file: ${authFilePath()}`));
+            return;
+        }
+
+        let token = (options.token || process.env.DELIMIT_AUTH_TOKEN || '').trim();
+        let email = (options.email || '').trim();
+
+        if (!token) {
+            console.log(chalk.blue.bold('\n  Delimit sign-in\n'));
+            console.log('  1. Open: ' + chalk.cyan('https://delimit.ai/account/cli'));
+            console.log('  2. Sign in and copy your CLI token');
+            console.log('  3. Paste it below\n');
+
+            const answers = await inquirer.prompt([
+                {
+                    type: 'password',
+                    name: 'token',
+                    message: 'Paste token:',
+                    mask: '*',
+                    validate: (input) => {
+                        const v = (input || '').trim();
+                        if (!v) return 'Token cannot be empty.';
+                        if (v.length < 16) return 'Token looks too short — copy the full string from delimit.ai/account/cli.';
+                        return true;
+                    },
+                },
+                {
+                    type: 'input',
+                    name: 'email',
+                    message: 'Email (optional, for display only):',
+                    default: '',
+                },
+            ]);
+            token = (answers.token || '').trim();
+            email = email || (answers.email || '').trim();
+        }
+
+        try {
+            const result = writeAuthToken({ token, email });
+            console.log('');
+            if (email) {
+                console.log(chalk.green(`  Signed in as ${email}. Hosted deliberation enabled.`));
+            } else {
+                console.log(chalk.green('  Signed in. Hosted deliberation enabled.'));
+            }
+            console.log(chalk.dim(`  Auth file: ${result.path} (mode 0600)`));
+            if (result.merged) {
+                console.log(chalk.dim('  Existing auth.json keys preserved.'));
+            }
+            console.log(chalk.dim('  To sign out: rm ' + result.path));
+            console.log('');
+        } catch (err) {
+            console.error(chalk.red(`  Sign-in failed: ${err.message}`));
+            process.exit(1);
+        }
     });
 
 // ---------------------------------------------------------------------------

--- a/lib/auth-signin.js
+++ b/lib/auth-signin.js
@@ -1,0 +1,136 @@
+// lib/auth-signin.js
+//
+// LED-2100: writes the delimit.ai OAuth bearer token to ~/.delimit/auth.json
+// so the gateway hosted-deliberation tier (LED-2092) can authenticate from
+// the CLI. The gateway reads `delimit_token` or `access_token` from this
+// file (see ai/deliberation.py::_read_oauth_token).
+//
+// Design notes
+//   - We MERGE into any existing auth.json rather than overwrite. The legacy
+//     `lib/auth-setup.js` writes {configured, timestamp, tools} into the same
+//     file for tool-credential bookkeeping; clobbering that would regress
+//     existing users. New keys (delimit_token, access_token, signed_in_at,
+//     email) live alongside the legacy keys.
+//   - File mode is 0600 (owner-only readable). Directory is created at 0700
+//     when missing.
+//   - Token shape is intentionally lax: accept anything non-empty after
+//     trimming. The gateway is the source of truth for token validity; the
+//     CLI must not try to second-guess JWT structure (Supabase tokens vs
+//     opaque tokens vs future formats).
+//
+// Returns: { path, email, signedInAt, merged } so callers can render a
+// consistent success message.
+
+const fs = require('fs');
+const path = require('path');
+const { delimitHome } = require('./delimit-home');
+
+const AUTH_FILE_BASENAME = 'auth.json';
+
+function authFilePath() {
+    return path.join(delimitHome(), AUTH_FILE_BASENAME);
+}
+
+/**
+ * Read the existing auth.json if present, returning a plain object. Returns
+ * an empty object on any read/parse error (we do not want to corrupt unrelated
+ * keys, but a malformed file should not block sign-in either — overwrite it).
+ */
+function readExistingAuth(filePath) {
+    if (!fs.existsSync(filePath)) {
+        return {};
+    }
+    try {
+        const raw = fs.readFileSync(filePath, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed;
+        }
+        return {};
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Persist a delimit.ai OAuth bearer token to ~/.delimit/auth.json with mode
+ * 0600. Existing keys (set by auth-setup.js or other flows) are preserved.
+ *
+ * @param {object} args
+ * @param {string} args.token   Bearer token returned by delimit.ai OAuth
+ * @param {string} [args.email] Email address associated with the account
+ * @param {string} [args.now]   Override clock for deterministic tests (ISO8601)
+ * @param {string} [args.home]  Override DELIMIT_HOME for tests
+ * @returns {{ path: string, email: string, signedInAt: string, merged: boolean }}
+ */
+function writeAuthToken(args) {
+    const opts = args || {};
+    const token = (opts.token || '').toString().trim();
+    if (!token) {
+        const err = new Error('Empty token; nothing written.');
+        err.code = 'DELIMIT_SIGNIN_EMPTY_TOKEN';
+        throw err;
+    }
+
+    const home = opts.home || delimitHome();
+    if (!fs.existsSync(home)) {
+        fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+    }
+    const filePath = path.join(home, AUTH_FILE_BASENAME);
+
+    const existing = readExistingAuth(filePath);
+    const merged = Object.keys(existing).length > 0;
+    const signedInAt = opts.now || new Date().toISOString();
+    const email = (opts.email || '').toString().trim();
+
+    const next = Object.assign({}, existing, {
+        delimit_token: token,
+        access_token: token,
+        signed_in_at: signedInAt,
+    });
+    if (email) {
+        next.email = email;
+    }
+
+    // Two-step write: write to a temp file with mode 0600, then rename. This
+    // avoids a window where the file exists with default permissions before
+    // chmod runs.
+    const tmpPath = filePath + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(next, null, 2), { mode: 0o600 });
+    // Some umasks may still strip group/other bits to match the requested
+    // mode; explicitly chmod to be safe (no-op on most platforms but cheap).
+    try {
+        fs.chmodSync(tmpPath, 0o600);
+    } catch {
+        // Non-POSIX filesystems may reject chmod; the file is already gated
+        // by writeFileSync mode, so this is best-effort.
+    }
+    fs.renameSync(tmpPath, filePath);
+
+    return {
+        path: filePath,
+        email,
+        signedInAt,
+        merged,
+    };
+}
+
+/**
+ * Read the currently stored token, if any. Returns "" when missing or
+ * malformed. Mirrors the gateway-side resolver (ai/deliberation.py::
+ * _read_oauth_token) so callers can implement `delimit signin --status`.
+ */
+function readCurrentToken() {
+    const filePath = authFilePath();
+    const data = readExistingAuth(filePath);
+    const token = (data.delimit_token || data.access_token || '').toString().trim();
+    return token;
+}
+
+module.exports = {
+    authFilePath,
+    readExistingAuth,
+    writeAuthToken,
+    readCurrentToken,
+    AUTH_FILE_BASENAME,
+};

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postinstall": "node scripts/postinstall.js",
     "sync-gateway": "bash scripts/sync-gateway.sh",
     "prepublishOnly": "bash scripts/publish-ci-guard.sh && npm run sync-gateway && bash scripts/build-license-core.sh && bash scripts/security-check.sh",
-    "test": "node --test tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js"
+    "test": "node --test tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js tests/auth-signin.test.js"
   },
   "keywords": [
     "openapi",

--- a/tests/auth-signin.test.js
+++ b/tests/auth-signin.test.js
@@ -1,0 +1,311 @@
+/**
+ * LED-2100: tests for lib/auth-signin.js — writes the delimit.ai OAuth
+ * bearer token to ~/.delimit/auth.json so the gateway hosted-deliberation
+ * tier can authenticate from the CLI.
+ *
+ * Locks the contract that:
+ *   - empty / whitespace-only tokens are rejected
+ *   - the file is written at mode 0600 (owner-only readable)
+ *   - both `delimit_token` and `access_token` are written (gateway
+ *     resolver uses delimit_token first, access_token as fallback)
+ *   - `signed_in_at` is ISO8601
+ *   - `email` is recorded when supplied, omitted when empty
+ *   - existing keys in auth.json (e.g. from `delimit auth`) are preserved
+ *   - readCurrentToken() round-trips written tokens
+ *   - malformed auth.json does not block sign-in
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+    authFilePath,
+    readExistingAuth,
+    writeAuthToken,
+    readCurrentToken,
+    AUTH_FILE_BASENAME,
+} = require('../lib/auth-signin');
+
+const ORIG_DELIMIT_HOME = process.env.DELIMIT_HOME;
+const ORIG_NAMESPACE_ROOT = process.env.DELIMIT_NAMESPACE_ROOT;
+
+let tmpHome;
+
+function setupTmpHome() {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-signin-test-'));
+    process.env.DELIMIT_HOME = tmpHome;
+    delete process.env.DELIMIT_NAMESPACE_ROOT;
+}
+
+function teardownTmpHome() {
+    try {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+    } catch {}
+    if (ORIG_DELIMIT_HOME === undefined) delete process.env.DELIMIT_HOME;
+    else process.env.DELIMIT_HOME = ORIG_DELIMIT_HOME;
+    if (ORIG_NAMESPACE_ROOT === undefined) delete process.env.DELIMIT_NAMESPACE_ROOT;
+    else process.env.DELIMIT_NAMESPACE_ROOT = ORIG_NAMESPACE_ROOT;
+}
+
+describe('lib/auth-signin: token validation', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('rejects an empty token', () => {
+        assert.throws(
+            () => writeAuthToken({ token: '' }),
+            /Empty token/
+        );
+    });
+
+    it('rejects a whitespace-only token', () => {
+        assert.throws(
+            () => writeAuthToken({ token: '   \n' }),
+            /Empty token/
+        );
+    });
+
+    it('throws an error with code DELIMIT_SIGNIN_EMPTY_TOKEN', () => {
+        try {
+            writeAuthToken({ token: '' });
+            assert.fail('expected throw');
+        } catch (err) {
+            assert.equal(err.code, 'DELIMIT_SIGNIN_EMPTY_TOKEN');
+        }
+    });
+
+    it('rejects a missing token argument', () => {
+        assert.throws(
+            () => writeAuthToken({}),
+            /Empty token/
+        );
+    });
+});
+
+describe('lib/auth-signin: file output', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('writes auth.json under DELIMIT_HOME', () => {
+        const result = writeAuthToken({ token: 'abcdef0123456789' });
+        assert.equal(result.path, path.join(tmpHome, AUTH_FILE_BASENAME));
+        assert.ok(fs.existsSync(result.path), 'auth.json should exist');
+    });
+
+    it('writes both delimit_token and access_token with the same value', () => {
+        const token = 'eyJhbGciOiJIUzI1NiJ9.payload.sig';
+        const result = writeAuthToken({ token });
+        const data = JSON.parse(fs.readFileSync(result.path, 'utf-8'));
+        assert.equal(data.delimit_token, token);
+        assert.equal(data.access_token, token);
+    });
+
+    it('writes signed_in_at as ISO8601 (when not overridden)', () => {
+        const result = writeAuthToken({ token: 'token-xyz-abcdef' });
+        const data = JSON.parse(fs.readFileSync(result.path, 'utf-8'));
+        assert.match(data.signed_in_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+        // Round-trips through Date.parse
+        assert.ok(!Number.isNaN(Date.parse(data.signed_in_at)));
+    });
+
+    it('honors the `now` override for deterministic tests', () => {
+        const fixed = '2026-05-08T12:00:00.000Z';
+        const result = writeAuthToken({ token: 'token-xyz-abcdef', now: fixed });
+        const data = JSON.parse(fs.readFileSync(result.path, 'utf-8'));
+        assert.equal(data.signed_in_at, fixed);
+        assert.equal(result.signedInAt, fixed);
+    });
+
+    it('records email when supplied', () => {
+        const result = writeAuthToken({ token: 'token-xyz-abcdef', email: 'user@example.com' });
+        const data = JSON.parse(fs.readFileSync(result.path, 'utf-8'));
+        assert.equal(data.email, 'user@example.com');
+        assert.equal(result.email, 'user@example.com');
+    });
+
+    it('omits email when not supplied', () => {
+        writeAuthToken({ token: 'token-xyz-abcdef' });
+        const data = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        assert.equal(data.email, undefined);
+    });
+
+    it('omits email when supplied as empty / whitespace', () => {
+        writeAuthToken({ token: 'token-xyz-abcdef', email: '   ' });
+        const data = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        assert.equal(data.email, undefined);
+    });
+
+    it('trims whitespace from the token before writing', () => {
+        const result = writeAuthToken({ token: '  padded-token-1234  ' });
+        const data = JSON.parse(fs.readFileSync(result.path, 'utf-8'));
+        assert.equal(data.delimit_token, 'padded-token-1234');
+    });
+});
+
+describe('lib/auth-signin: file permissions', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('creates auth.json with mode 0600', () => {
+        const result = writeAuthToken({ token: 'token-xyz-abcdef' });
+        const stat = fs.statSync(result.path);
+        // Mask off the file-type bits, keep only the 0o7777 permission bits.
+        const mode = stat.mode & 0o7777;
+        assert.equal(mode, 0o600, `expected 0600, got 0o${mode.toString(8)}`);
+    });
+
+    it('creates DELIMIT_HOME at mode 0700 when missing', () => {
+        // Remove the temp home dir so writeAuthToken has to create it.
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+        assert.ok(!fs.existsSync(tmpHome));
+
+        writeAuthToken({ token: 'token-xyz-abcdef' });
+        assert.ok(fs.existsSync(tmpHome));
+        const stat = fs.statSync(tmpHome);
+        // Some CI filesystems strip mode bits; allow either 0700 (the
+        // requested mode) or whatever the umask permits, but require at
+        // minimum that group/other read bits are clear.
+        const mode = stat.mode & 0o7777;
+        assert.equal(mode & 0o077, 0, `dir mode should not allow group/other access; got 0o${mode.toString(8)}`);
+    });
+});
+
+describe('lib/auth-signin: merge semantics', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('preserves existing keys written by lib/auth-setup.js', () => {
+        // Simulate what lib/auth-setup.js writes today.
+        const legacy = {
+            configured: true,
+            timestamp: '2026-01-01T00:00:00.000Z',
+            tools: ['github', 'claude'],
+        };
+        fs.writeFileSync(authFilePath(), JSON.stringify(legacy, null, 2));
+
+        const result = writeAuthToken({ token: 'token-xyz-abcdef' });
+        assert.equal(result.merged, true);
+
+        const data = JSON.parse(fs.readFileSync(result.path, 'utf-8'));
+        assert.equal(data.configured, true);
+        assert.equal(data.timestamp, '2026-01-01T00:00:00.000Z');
+        assert.deepEqual(data.tools, ['github', 'claude']);
+        assert.equal(data.delimit_token, 'token-xyz-abcdef');
+        assert.equal(data.access_token, 'token-xyz-abcdef');
+    });
+
+    it('reports merged=false when no auth.json existed', () => {
+        const result = writeAuthToken({ token: 'token-xyz-abcdef' });
+        assert.equal(result.merged, false);
+    });
+
+    it('overwrites a stale token on re-signin', () => {
+        writeAuthToken({ token: 'old-token-1234567890' });
+        writeAuthToken({ token: 'new-token-1234567890' });
+        const data = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        assert.equal(data.delimit_token, 'new-token-1234567890');
+        assert.equal(data.access_token, 'new-token-1234567890');
+    });
+
+    it('treats a malformed auth.json as empty and overwrites it', () => {
+        fs.writeFileSync(authFilePath(), '{ this is not valid json');
+        const result = writeAuthToken({ token: 'token-xyz-abcdef' });
+        // We treat malformed files as missing; merged should be false.
+        assert.equal(result.merged, false);
+        const data = JSON.parse(fs.readFileSync(result.path, 'utf-8'));
+        assert.equal(data.delimit_token, 'token-xyz-abcdef');
+    });
+
+    it('treats a JSON array as empty (object-only contract)', () => {
+        fs.writeFileSync(authFilePath(), '[]');
+        const result = writeAuthToken({ token: 'token-xyz-abcdef' });
+        assert.equal(result.merged, false);
+    });
+});
+
+describe('lib/auth-signin: readCurrentToken', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns "" when auth.json is missing', () => {
+        assert.equal(readCurrentToken(), '');
+    });
+
+    it('returns "" when auth.json has neither token key', () => {
+        fs.writeFileSync(authFilePath(), JSON.stringify({ configured: true }));
+        assert.equal(readCurrentToken(), '');
+    });
+
+    it('round-trips delimit_token after writeAuthToken', () => {
+        writeAuthToken({ token: 'round-trip-token-1234' });
+        assert.equal(readCurrentToken(), 'round-trip-token-1234');
+    });
+
+    it('falls back to access_token when delimit_token is missing', () => {
+        // Mirrors gateway-side resolver: prefer delimit_token, fall back to
+        // access_token. This covers the case where some other tool (or a
+        // future surface) wrote only access_token.
+        fs.writeFileSync(authFilePath(), JSON.stringify({ access_token: 'fallback-token-9999' }));
+        assert.equal(readCurrentToken(), 'fallback-token-9999');
+    });
+
+    it('prefers delimit_token over access_token when both are present', () => {
+        fs.writeFileSync(authFilePath(), JSON.stringify({
+            delimit_token: 'primary-token-1111',
+            access_token: 'secondary-token-2222',
+        }));
+        assert.equal(readCurrentToken(), 'primary-token-1111');
+    });
+
+    it('returns "" when auth.json is malformed', () => {
+        fs.writeFileSync(authFilePath(), '{ broken');
+        assert.equal(readCurrentToken(), '');
+    });
+});
+
+describe('lib/auth-signin: readExistingAuth', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns {} when the file is missing', () => {
+        assert.deepEqual(readExistingAuth(authFilePath()), {});
+    });
+
+    it('returns {} for malformed JSON', () => {
+        fs.writeFileSync(authFilePath(), '{ not json');
+        assert.deepEqual(readExistingAuth(authFilePath()), {});
+    });
+
+    it('returns the parsed object for valid JSON', () => {
+        fs.writeFileSync(authFilePath(), JSON.stringify({ a: 1, b: 'two' }));
+        assert.deepEqual(readExistingAuth(authFilePath()), { a: 1, b: 'two' });
+    });
+
+    it('returns {} for non-object JSON (array, primitive)', () => {
+        fs.writeFileSync(authFilePath(), JSON.stringify(['a', 'b']));
+        assert.deepEqual(readExistingAuth(authFilePath()), {});
+
+        fs.writeFileSync(authFilePath(), JSON.stringify('just a string'));
+        assert.deepEqual(readExistingAuth(authFilePath()), {});
+    });
+});
+
+describe('lib/auth-signin: authFilePath', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns <DELIMIT_HOME>/auth.json', () => {
+        assert.equal(authFilePath(), path.join(tmpHome, AUTH_FILE_BASENAME));
+    });
+
+    it('re-resolves on every call (honors env mutation)', () => {
+        const first = authFilePath();
+        process.env.DELIMIT_HOME = path.join(tmpHome, 'alt');
+        const second = authFilePath();
+        assert.notEqual(first, second);
+        assert.equal(second, path.join(tmpHome, 'alt', AUTH_FILE_BASENAME));
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `delimit signin` command that writes the delimit.ai OAuth bearer token to `~/.delimit/auth.json` (mode 0600), so the gateway hosted-deliberation tier ([LED-2092](https://github.com/delimit-ai/delimit-gateway/pull/131), merged 2026-05-08) can authenticate from CLI.
- Closes the Free→Pro funnel gap: prior to this PR, CLI users could only authenticate via the `DELIMIT_AUTH_TOKEN` env-var workaround.
- Tracking item: **LED-2100**.

## Approach taken: fallback-only (paste-token)

Per the directive's recommendation, this PR ships the **paste-token flow only**. The browser-callback flow is deferred to a follow-up LED once delimit.ai (`/home/delimit/delimit-ui`) ships a `cli=1&port=<n>` redirect endpoint. Rationale:

- One-PR delivery; unblocks the gateway's hosted-deliberation path immediately for SSH / headless users.
- No coupling to delimit.ai-side changes; ships independently.
- Browser-callback can be added without breaking the paste-token surface (`--token` flag remains the primary contract).

## Surface

```
delimit signin                          # interactive: prompt for paste
delimit signin --token <bearer>         # non-interactive (CI / scripts)
delimit signin --token <bearer> --email user@example.com
delimit signin --status                 # check current sign-in state
```

Output of a successful signin:

```
  Signed in as user@example.com. Hosted deliberation enabled.
  Auth file: /home/<user>/.delimit/auth.json (mode 0600)
  To sign out: rm /home/<user>/.delimit/auth.json
```

## File contract (auth.json)

```json
{
  "delimit_token": "<bearer>",
  "access_token":  "<bearer>",
  "signed_in_at":  "<ISO8601>",
  "email":         "<email>"     // optional
}
```

Both `delimit_token` and `access_token` are written with the same value to match the gateway resolver, which prefers `delimit_token` and falls back to `access_token` (see `ai/deliberation.py::_read_oauth_token` in the gateway).

## Customer protection

- **No changes** to `delimit activate` or any existing Pro license-key surface. `signin` is a new, distinct command for OAuth bearer tokens.
- **Merge semantics**: existing `auth.json` keys (e.g. `{configured, timestamp, tools}` written by `lib/auth-setup.js` via `delimit auth`) are preserved. New keys are added alongside.
- **File mode 0600** enforced via `writeFileSync({mode: 0o600})` + explicit `chmodSync` belt-and-suspenders. Verified in tests.
- **Atomic write**: `tmp + rename` to avoid a window where the file exists with default permissions.
- **Malformed `auth.json`** is treated as empty and overwritten (does not block sign-in).

## Tests

- `tests/auth-signin.test.js`: 31 new tests — token validation, file mode, ISO8601 timestamp, email handling, merge semantics, malformed-file recovery, `readCurrentToken` round-trip (mirrors gateway resolver order: prefer `delimit_token`, fall back to `access_token`).
- Full suite: **227 pass** (was 196 before this PR, +31).

## Test plan

- [x] `npm test` — all 227 tests pass locally.
- [x] Manual smoke: `delimit signin --token …` writes `auth.json` at mode 0600 with both keys.
- [x] Manual smoke: `--status` exits 0 when signed in, exits 1 when not signed in.
- [x] Manual smoke: existing `auth.json` from `delimit auth` is preserved across signin.
- [x] Manual smoke: `delimit signin --help` and `delimit --help` both surface the new command.
- [ ] CI green on this PR.
- [ ] Post-merge: sign in on a real machine and verify `delimit deliberate "test"` picks up the token via the gateway resolver.

## Follow-ups (not in this PR)

- **delimit.ai signin endpoint**: add `?cli=1&port=<port>` query handling to `/home/delimit/delimit-ui/app/api/auth/signin/` to enable the browser-callback flow. Once shipped, add a `delimit signin --browser` flag here that spawns a localhost listener and opens the user's default browser. Tracking as a separate LED.
- **`delimit signout`**: convenience wrapper for `rm ~/.delimit/auth.json` that scrubs only the OAuth keys (preserving merged keys from `delimit auth`).

## Branch / commits
- Branch: `feat/led-2100-cli-signin`
- Commit: `f510231`