### PR TITLE
feat(cli): delimit signout + Free BYOK migration banner

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -69,7 +69,7 @@ function normalizeNaturalLanguageArgs(argv) {
     const explicitCommands = new Set([
         'install', 'mode', 'status', 'session', 'build', 'ask', 'policy', 'auth', 'audit',
         'explain-decision', 'uninstall', 'proxy', 'hook', 'version', 'vault', 'deliberate',
-        'remember', 'recall', 'forget', 'report', 'signin', 'activate'
+        'remember', 'recall', 'forget', 'report', 'signin', 'signout', 'activate'
     ]);
     if (explicitCommands.has((raw[0] || '').toLowerCase())) {
         return raw;
@@ -5737,10 +5737,52 @@ program
             if (result.merged) {
                 console.log(chalk.dim('  Existing auth.json keys preserved.'));
             }
-            console.log(chalk.dim('  To sign out: rm ' + result.path));
+            console.log(chalk.dim('  To sign out: delimit signout'));
             console.log('');
         } catch (err) {
             console.error(chalk.red(`  Sign-in failed: ${err.message}`));
+            process.exit(1);
+        }
+    });
+
+// ---------------------------------------------------------------------------
+// LED-2106: `delimit signout` — remove the OAuth bearer token written by
+// `delimit signin` (LED-2100) without clobbering the legacy bookkeeping
+// keys (configured / timestamp / tools) written by `delimit auth`. Today
+// users sign out via `rm ~/.delimit/auth.json` which wipes everything;
+// this command scrubs only the OAuth-related keys.
+//
+// Surface contract:
+//   - Removes ONLY: delimit_token, access_token, signed_in_at, email
+//   - Preserves: every other key (e.g. configured, timestamp, tools)
+//   - Deletes auth.json entirely if it has no remaining keys after scrub
+//   - Idempotent: safe to run when not signed in (prints "Not signed in.")
+// ---------------------------------------------------------------------------
+program
+    .command('signout')
+    .description('Sign out of delimit.ai (removes the hosted-deliberation token)')
+    .action(async () => {
+        const { removeAuthToken } = require('../lib/auth-signout');
+        try {
+            const result = removeAuthToken();
+            if (!result.changed) {
+                console.log(chalk.yellow('  Not signed in.'));
+                return;
+            }
+            console.log('');
+            if (result.email) {
+                console.log(chalk.green(`  Signed out (${result.email}).`));
+            } else {
+                console.log(chalk.green('  Signed out.'));
+            }
+            if (result.deleted) {
+                console.log(chalk.dim(`  Removed: ${result.path}`));
+            } else {
+                console.log(chalk.dim(`  Auth file: ${result.path} (other keys preserved)`));
+            }
+            console.log('');
+        } catch (err) {
+            console.error(chalk.red(`  Sign-out failed: ${err.message}`));
             process.exit(1);
         }
     });
@@ -5934,6 +5976,21 @@ program
     .option('--mode <mode>', 'Deliberation mode: quick | dialogue | debate', 'dialogue')
     .option('--question <q>', 'Question to deliberate (alternative to positional arg)')
     .action(async (questionParts, options) => {
+        // LED-2095: one-time migration banner for Free + BYOK users to
+        // surface the LED-2092 / LED-2093 ephemeral-Free-tier change.
+        // This fires on the first deliberation-adjacent call after the
+        // upgrade and never again on this machine.
+        try {
+            const { maybeShowMigrationBanner } = require('../lib/migration-2092-banner');
+            const banner = maybeShowMigrationBanner();
+            if (banner.shown) {
+                console.log(chalk.yellow(banner.text));
+            }
+        } catch {
+            // Banner is purely informational; never block deliberation
+            // because of a flag-file write or models.json read error.
+        }
+
         const question = options.question || (questionParts.length > 0 ? questionParts.join(' ') : null);
 
         if (options.list) {
@@ -6150,6 +6207,18 @@ program
     .description('Configure deliberation model API keys (BYOK)')
     .option('--status', 'Show current model configuration (non-interactive)')
     .action(async (options) => {
+        // LED-2095: deliberation-adjacent surface — also a valid trigger
+        // point for the one-time migration banner. See lib/migration-2092-banner.js.
+        try {
+            const { maybeShowMigrationBanner } = require('../lib/migration-2092-banner');
+            const banner = maybeShowMigrationBanner();
+            if (banner.shown) {
+                console.log(chalk.yellow(banner.text));
+            }
+        } catch {
+            // Banner is informational; never block the command on banner errors.
+        }
+
         const config = loadModelsConfig();
 
         // --status: non-interactive output

--- a/lib/auth-signout.js
+++ b/lib/auth-signout.js
@@ -1,0 +1,169 @@
+// lib/auth-signout.js
+//
+// LED-2106: convenience wrapper around `rm ~/.delimit/auth.json` that ONLY
+// removes the OAuth-related keys written by `delimit signin` (LED-2100) and
+// preserves the legacy bookkeeping keys (`configured`, `timestamp`, `tools`)
+// written by `lib/auth-setup.js`. Wiping the whole file regresses any user
+// who ran `delimit auth` for tool credential bookkeeping.
+//
+// Design notes
+//   - We MERGE-DELETE: read the file, drop the OAuth keys, write the
+//     remainder back. If the post-scrub object has zero keys, we delete
+//     the file entirely (cleanest state — equivalent to never having run
+//     `delimit signin` or `delimit auth`).
+//   - File mode is 0600 (owner-only readable). Write is atomic (tmp +
+//     rename) — same pattern as lib/auth-signin.js.
+//   - If auth.json is missing, malformed, or has no OAuth keys at all,
+//     this is a no-op (returns { changed: false }). The CLI prints
+//     "Not signed in." and exits 0 in that case.
+//
+// OAuth keys removed:
+//   - delimit_token
+//   - access_token
+//   - signed_in_at
+//   - email
+//
+// Returns: { path, changed, deleted, email } so callers can render a
+// consistent success message.
+
+const fs = require('fs');
+const path = require('path');
+const { delimitHome } = require('./delimit-home');
+
+const AUTH_FILE_BASENAME = 'auth.json';
+
+// The OAuth-related keys that `delimit signin` writes. Sign-out removes
+// EXACTLY these and nothing else. Adding to this list is a behavior
+// change that needs coordinated review (the gateway resolver in
+// ai/deliberation.py::_read_oauth_token reads `delimit_token` /
+// `access_token`).
+const OAUTH_KEYS = Object.freeze([
+    'delimit_token',
+    'access_token',
+    'signed_in_at',
+    'email',
+]);
+
+function authFilePath() {
+    return path.join(delimitHome(), AUTH_FILE_BASENAME);
+}
+
+/**
+ * Read the existing auth.json if present, returning a plain object. Returns
+ * an empty object on any read/parse error (consistent with auth-signin.js).
+ */
+function readExistingAuth(filePath) {
+    if (!fs.existsSync(filePath)) {
+        return {};
+    }
+    try {
+        const raw = fs.readFileSync(filePath, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed;
+        }
+        return {};
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Write `data` to auth.json atomically with mode 0600. Mirrors the pattern
+ * used by lib/auth-signin.js::writeAuthToken.
+ */
+function writeAuthAtomic(filePath, data) {
+    const tmpPath = filePath + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+    try {
+        fs.chmodSync(tmpPath, 0o600);
+    } catch {
+        // Non-POSIX filesystems may reject chmod; the file is already gated
+        // by writeFileSync mode, so this is best-effort.
+    }
+    fs.renameSync(tmpPath, filePath);
+}
+
+/**
+ * Remove the OAuth keys from ~/.delimit/auth.json, preserving any other
+ * keys written by `delimit auth` / `lib/auth-setup.js`. If no OAuth keys
+ * are present, this is a no-op. If removing the OAuth keys leaves the
+ * file empty, the file is deleted.
+ *
+ * @param {object} [args]
+ * @param {string} [args.home]  Override DELIMIT_HOME for tests
+ * @returns {{ path: string, changed: boolean, deleted: boolean, email: string }}
+ */
+function removeAuthToken(args) {
+    const opts = args || {};
+    const home = opts.home || delimitHome();
+    const filePath = path.join(home, AUTH_FILE_BASENAME);
+
+    if (!fs.existsSync(filePath)) {
+        return { path: filePath, changed: false, deleted: false, email: '' };
+    }
+
+    const existing = readExistingAuth(filePath);
+    if (Object.keys(existing).length === 0) {
+        // Malformed / empty / array. Nothing meaningful to scrub.
+        return { path: filePath, changed: false, deleted: false, email: '' };
+    }
+
+    // Detect whether any OAuth keys are actually present. If not, we treat
+    // this as "not signed in" and return changed=false WITHOUT touching the
+    // file (preserves mtime / inode / mode).
+    const hasOAuthKey = OAUTH_KEYS.some((k) => Object.prototype.hasOwnProperty.call(existing, k));
+    if (!hasOAuthKey) {
+        return { path: filePath, changed: false, deleted: false, email: '' };
+    }
+
+    const previousEmail = (existing.email || '').toString().trim();
+
+    // Build the scrubbed object: keep everything that is NOT an OAuth key.
+    const scrubbed = {};
+    for (const [k, v] of Object.entries(existing)) {
+        if (!OAUTH_KEYS.includes(k)) {
+            scrubbed[k] = v;
+        }
+    }
+
+    if (Object.keys(scrubbed).length === 0) {
+        // Nothing left worth keeping — delete the file entirely so the
+        // next session sees the cleanest possible state.
+        try {
+            fs.unlinkSync(filePath);
+        } catch {
+            // If unlink fails for some reason, fall back to writing an
+            // empty object (still valid JSON, still mode 0600).
+            writeAuthAtomic(filePath, {});
+            return {
+                path: filePath,
+                changed: true,
+                deleted: false,
+                email: previousEmail,
+            };
+        }
+        return {
+            path: filePath,
+            changed: true,
+            deleted: true,
+            email: previousEmail,
+        };
+    }
+
+    writeAuthAtomic(filePath, scrubbed);
+    return {
+        path: filePath,
+        changed: true,
+        deleted: false,
+        email: previousEmail,
+    };
+}
+
+module.exports = {
+    authFilePath,
+    readExistingAuth,
+    removeAuthToken,
+    AUTH_FILE_BASENAME,
+    OAUTH_KEYS,
+};

--- a/lib/migration-2092-banner.js
+++ b/lib/migration-2092-banner.js
@@ -1,0 +1,213 @@
+// lib/migration-2092-banner.js
+//
+// LED-2095: one-time migration banner shown to existing Free-tier users
+// who have BYOK deliberation configured. Surfaces the LED-2092 / LED-2093
+// gateway behavior change: Free-tier BYOK deliberation is now operationally
+// ephemeral (no persistent transcript, no signed attestation, no replay
+// URL). Pro-tier behavior is unchanged.
+//
+// Trigger conditions (ALL must be true):
+//   1. ~/.delimit/models.json exists with at least one BYOK entry
+//      (entry.enabled === true AND entry.api_key truthy)
+//   2. User is on the Free tier (no Pro/Premium/Enterprise license active
+//      per the same check used by lib/wrap-engine.js)
+//   3. The flag file ~/.delimit/migration_2092.shown does not exist yet
+//
+// On trigger: print the banner to stdout/stderr (caller's choice — we
+// return the banner string and let the caller handle output) and write
+// the flag file with `{ shown_at: ISO8601, version: <package version> }`
+// so the banner never fires again on the same machine.
+//
+// Scope: trigger on the next deliberation-adjacent CLI call (deliberate,
+// models). Do NOT trigger on every CLI call (would be noise). Do NOT
+// trigger for Pro customers (no behavior change for them). Do NOT
+// trigger for Free users without BYOK (they had no transcripts to lose).
+
+const fs = require('fs');
+const path = require('path');
+const { delimitHome, homeSubpath } = require('./delimit-home');
+
+const FLAG_FILE_BASENAME = 'migration_2092.shown';
+const MODELS_CONFIG_BASENAME = 'models.json';
+const LICENSE_FILE_BASENAME = 'license.json';
+
+// Banner copy — locked. No em-dashes (per LED-2095 brief). No founder
+// identity strings. Positive tone. The Pro upsell is a single line at
+// the end with the pricing URL; do not expand without coordinated copy
+// review.
+const BANNER_BODY = [
+    '',
+    'Free deliberations now print to stdout only.',
+    '',
+    'Your existing transcripts under ~/.delimit/memory/deliberations/ are preserved.',
+    'New deliberations on Free tier are ephemeral by design.',
+    '',
+    'Pro turns every deliberation into a signed, replayable attestation',
+    'with 365-day retention: delimit.ai/pricing',
+    '',
+].join('\n');
+
+function flagFilePath() {
+    return homeSubpath(FLAG_FILE_BASENAME);
+}
+
+function modelsConfigPath() {
+    return homeSubpath(MODELS_CONFIG_BASENAME);
+}
+
+function licenseFilePath() {
+    return homeSubpath(LICENSE_FILE_BASENAME);
+}
+
+/**
+ * Detect whether the user has at least one BYOK model entry configured.
+ * Mirrors the truthiness rule used by bin/delimit-cli.js::getModelStatus:
+ * `entry.enabled === true AND entry.api_key truthy`.
+ */
+function hasByokConfigured() {
+    const p = modelsConfigPath();
+    if (!fs.existsSync(p)) return false;
+    let config;
+    try {
+        config = JSON.parse(fs.readFileSync(p, 'utf-8'));
+    } catch {
+        return false;
+    }
+    if (!config || typeof config !== 'object' || Array.isArray(config)) {
+        return false;
+    }
+    for (const entry of Object.values(config)) {
+        if (entry && typeof entry === 'object' && entry.enabled && entry.api_key) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Detect whether the user has an active Pro/Premium/Enterprise license.
+ * Mirrors the rule used by lib/wrap-engine.js::checkQuota — keep these in
+ * lockstep. A missing/malformed license.json means Free.
+ */
+function hasProLicense() {
+    const p = licenseFilePath();
+    if (!fs.existsSync(p)) return false;
+    try {
+        const lic = JSON.parse(fs.readFileSync(p, 'utf-8'));
+        if (lic && lic.valid && ['pro', 'premium', 'enterprise'].includes(lic.tier)) {
+            return true;
+        }
+    } catch {
+        return false;
+    }
+    return false;
+}
+
+/**
+ * Check whether the migration flag file has already been written. Once
+ * written, the banner is suppressed forever on this machine (the file is
+ * the source of truth — even a corrupt JSON body counts as "shown" so a
+ * partially-written flag does not re-trigger the banner).
+ */
+function hasShownBanner() {
+    return fs.existsSync(flagFilePath());
+}
+
+/**
+ * Should the banner trigger right now? All three conditions must hold:
+ * BYOK configured, no Pro license, flag file absent.
+ */
+function shouldShowBanner() {
+    if (hasShownBanner()) return false;
+    if (hasProLicense()) return false;
+    if (!hasByokConfigured()) return false;
+    return true;
+}
+
+/**
+ * Persist the flag file so the banner never fires again. Best-effort:
+ * directory is created at 0700 if missing, file is written at default
+ * mode (no secrets in this file — just a timestamp + version).
+ *
+ * @param {object} [args]
+ * @param {string} [args.now]      ISO8601 override for tests
+ * @param {string} [args.version]  CLI version string
+ */
+function writeShownFlag(args) {
+    const opts = args || {};
+    const home = delimitHome();
+    if (!fs.existsSync(home)) {
+        fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+    }
+    const payload = {
+        shown_at: opts.now || new Date().toISOString(),
+        version: opts.version || resolveCliVersion(),
+        led: 'LED-2095',
+    };
+    const tmpPath = flagFilePath() + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2));
+    fs.renameSync(tmpPath, flagFilePath());
+}
+
+function resolveCliVersion() {
+    try {
+        // package.json sits two levels up from lib/migration-2092-banner.js
+        const pkg = require(path.join(__dirname, '..', 'package.json'));
+        return pkg.version || 'unknown';
+    } catch {
+        return 'unknown';
+    }
+}
+
+/**
+ * The exact banner text shown to triggered users. Exposed so tests can
+ * snapshot it without re-running the trigger logic.
+ */
+function bannerText() {
+    return BANNER_BODY;
+}
+
+/**
+ * Composite entry point used by the CLI. If conditions are met, returns
+ * the banner string AND writes the flag file. If conditions are not met,
+ * returns "" and does not touch the filesystem.
+ *
+ * The CLI is responsible for printing the returned string. Returning the
+ * string (rather than printing here) keeps this module side-effect-light
+ * and lets tests assert on the output without capturing stdout.
+ *
+ * @param {object} [args]
+ * @param {string} [args.now]      ISO8601 override for the flag-file
+ *                                 timestamp (deterministic tests)
+ * @param {string} [args.version]  Override the CLI version string
+ * @returns {{ shown: boolean, text: string }}
+ */
+function maybeShowMigrationBanner(args) {
+    if (!shouldShowBanner()) {
+        return { shown: false, text: '' };
+    }
+    try {
+        writeShownFlag(args);
+    } catch {
+        // If we cannot persist the flag, do NOT show the banner —
+        // showing it without persisting would re-fire on every call.
+        return { shown: false, text: '' };
+    }
+    return { shown: true, text: bannerText() };
+}
+
+module.exports = {
+    FLAG_FILE_BASENAME,
+    MODELS_CONFIG_BASENAME,
+    LICENSE_FILE_BASENAME,
+    flagFilePath,
+    modelsConfigPath,
+    licenseFilePath,
+    hasByokConfigured,
+    hasProLicense,
+    hasShownBanner,
+    shouldShowBanner,
+    writeShownFlag,
+    bannerText,
+    maybeShowMigrationBanner,
+};

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postinstall": "node scripts/postinstall.js",
     "sync-gateway": "bash scripts/sync-gateway.sh",
     "prepublishOnly": "bash scripts/publish-ci-guard.sh && npm run sync-gateway && bash scripts/build-license-core.sh && bash scripts/security-check.sh",
-    "test": "node --test tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js tests/auth-signin.test.js"
+    "test": "node --test tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js tests/auth-signin.test.js tests/auth-signout.test.js tests/migration-2092-banner.test.js"
   },
   "keywords": [
     "openapi",

--- a/tests/auth-signout.test.js
+++ b/tests/auth-signout.test.js
@@ -1,0 +1,327 @@
+/**
+ * LED-2106: tests for lib/auth-signout.js — removes the OAuth bearer
+ * token written by `delimit signin` (LED-2100) without clobbering the
+ * legacy bookkeeping keys written by `lib/auth-setup.js`.
+ *
+ * Locks the contract that:
+ *   - signed-in scrub leaves bookkeeping keys (`configured`, `timestamp`,
+ *     `tools`) intact
+ *   - signed-in scrub removes EXACTLY the OAuth keys (delimit_token,
+ *     access_token, signed_in_at, email) and nothing else
+ *   - no-op when not signed in (file missing, malformed, or no OAuth keys)
+ *   - the file is written atomically (tmp + rename) at mode 0600
+ *   - the file is deleted entirely when scrubbing leaves it empty
+ *   - the previously-signed-in email is returned to callers for display
+ *   - readExistingAuth is consistent with auth-signin.js (object-only)
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+    authFilePath,
+    readExistingAuth,
+    removeAuthToken,
+    AUTH_FILE_BASENAME,
+    OAUTH_KEYS,
+} = require('../lib/auth-signout');
+
+// Reuse the writer from auth-signin so the round-trip test exercises the
+// real signin path rather than a hand-built file.
+const { writeAuthToken } = require('../lib/auth-signin');
+
+const ORIG_DELIMIT_HOME = process.env.DELIMIT_HOME;
+const ORIG_NAMESPACE_ROOT = process.env.DELIMIT_NAMESPACE_ROOT;
+
+let tmpHome;
+
+function setupTmpHome() {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-signout-test-'));
+    process.env.DELIMIT_HOME = tmpHome;
+    delete process.env.DELIMIT_NAMESPACE_ROOT;
+}
+
+function teardownTmpHome() {
+    try {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+    } catch {}
+    if (ORIG_DELIMIT_HOME === undefined) delete process.env.DELIMIT_HOME;
+    else process.env.DELIMIT_HOME = ORIG_DELIMIT_HOME;
+    if (ORIG_NAMESPACE_ROOT === undefined) delete process.env.DELIMIT_NAMESPACE_ROOT;
+    else process.env.DELIMIT_NAMESPACE_ROOT = ORIG_NAMESPACE_ROOT;
+}
+
+describe('lib/auth-signout: OAUTH_KEYS contract', () => {
+    it('exports the exact OAuth-related keys signin writes', () => {
+        // If signin grows a new OAuth key (e.g. refresh_token), signout
+        // MUST scrub it too — otherwise sign-out leaves stale state.
+        // This test guards against drift between the two files.
+        assert.deepEqual(
+            [...OAUTH_KEYS].sort(),
+            ['access_token', 'delimit_token', 'email', 'signed_in_at']
+        );
+    });
+
+    it('OAUTH_KEYS is frozen (immutable contract)', () => {
+        assert.ok(Object.isFrozen(OAUTH_KEYS));
+    });
+});
+
+describe('lib/auth-signout: no-op cases', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns changed=false when auth.json does not exist', () => {
+        const result = removeAuthToken();
+        assert.equal(result.changed, false);
+        assert.equal(result.deleted, false);
+        assert.equal(result.email, '');
+    });
+
+    it('returns changed=false when auth.json is malformed JSON', () => {
+        fs.writeFileSync(authFilePath(), '{ this is not valid json');
+        const result = removeAuthToken();
+        assert.equal(result.changed, false);
+        // Malformed file is left untouched (we do not delete user data
+        // we cannot parse).
+        assert.ok(fs.existsSync(authFilePath()));
+    });
+
+    it('returns changed=false when auth.json is a JSON array', () => {
+        fs.writeFileSync(authFilePath(), JSON.stringify(['a', 'b']));
+        const result = removeAuthToken();
+        assert.equal(result.changed, false);
+    });
+
+    it('returns changed=false when auth.json has no OAuth keys', () => {
+        // Simulate a user who only ran `delimit auth` (legacy bookkeeping)
+        // but never `delimit signin` — there is nothing to sign out from.
+        const legacy = {
+            configured: true,
+            timestamp: '2026-01-01T00:00:00.000Z',
+            tools: ['github', 'claude'],
+        };
+        fs.writeFileSync(authFilePath(), JSON.stringify(legacy, null, 2));
+
+        const result = removeAuthToken();
+        assert.equal(result.changed, false);
+        assert.equal(result.email, '');
+
+        // File is left exactly as we found it.
+        const after = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        assert.deepEqual(after, legacy);
+    });
+});
+
+describe('lib/auth-signout: scrub semantics', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('removes ONLY the OAuth keys, preserving everything else', () => {
+        // Hand-build a realistic merged auth.json: legacy bookkeeping +
+        // OAuth keys written by signin.
+        const legacy = {
+            configured: true,
+            timestamp: '2026-01-01T00:00:00.000Z',
+            tools: ['github', 'claude'],
+        };
+        fs.writeFileSync(authFilePath(), JSON.stringify(legacy, null, 2));
+
+        writeAuthToken({ token: 'token-xyz-abcdef', email: 'user@example.com' });
+
+        // Sanity: all keys are now present.
+        const before = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        assert.equal(before.delimit_token, 'token-xyz-abcdef');
+        assert.equal(before.access_token, 'token-xyz-abcdef');
+        assert.equal(before.email, 'user@example.com');
+        assert.ok(before.signed_in_at);
+        assert.equal(before.configured, true);
+
+        const result = removeAuthToken();
+        assert.equal(result.changed, true);
+        assert.equal(result.deleted, false);
+        assert.equal(result.email, 'user@example.com');
+
+        const after = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        // OAuth keys are gone.
+        assert.equal(after.delimit_token, undefined);
+        assert.equal(after.access_token, undefined);
+        assert.equal(after.signed_in_at, undefined);
+        assert.equal(after.email, undefined);
+        // Bookkeeping keys are intact.
+        assert.equal(after.configured, true);
+        assert.equal(after.timestamp, '2026-01-01T00:00:00.000Z');
+        assert.deepEqual(after.tools, ['github', 'claude']);
+    });
+
+    it('returns the previously-signed-in email for display', () => {
+        writeAuthToken({ token: 'token-xyz-abcdef', email: 'someone@example.com' });
+        // Add a bookkeeping key so the file does not get deleted on scrub
+        // (cleaner email-roundtrip assertion).
+        const merged = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        merged.configured = true;
+        fs.writeFileSync(authFilePath(), JSON.stringify(merged, null, 2));
+
+        const result = removeAuthToken();
+        assert.equal(result.email, 'someone@example.com');
+    });
+
+    it('returns email="" when the previous sign-in had no email', () => {
+        writeAuthToken({ token: 'token-xyz-abcdef' });
+        const merged = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        merged.configured = true;
+        fs.writeFileSync(authFilePath(), JSON.stringify(merged, null, 2));
+
+        const result = removeAuthToken();
+        assert.equal(result.email, '');
+    });
+
+    it('removes only delimit_token / access_token / signed_in_at when no email was set', () => {
+        writeAuthToken({ token: 'token-xyz-abcdef' }); // no email
+        const merged = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        merged.configured = true;
+        merged.tools = ['github'];
+        fs.writeFileSync(authFilePath(), JSON.stringify(merged, null, 2));
+
+        removeAuthToken();
+        const after = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        assert.equal(after.delimit_token, undefined);
+        assert.equal(after.access_token, undefined);
+        assert.equal(after.signed_in_at, undefined);
+        assert.equal(after.configured, true);
+        assert.deepEqual(after.tools, ['github']);
+    });
+
+    it('handles a partial OAuth state (only access_token written)', () => {
+        // Some other tool (or future surface) might write only one of the
+        // two token keys. Sign-out should still scrub it.
+        fs.writeFileSync(authFilePath(), JSON.stringify({
+            configured: true,
+            access_token: 'fallback-token-9999',
+        }));
+        const result = removeAuthToken();
+        assert.equal(result.changed, true);
+        const after = JSON.parse(fs.readFileSync(authFilePath(), 'utf-8'));
+        assert.equal(after.access_token, undefined);
+        assert.equal(after.configured, true);
+    });
+});
+
+describe('lib/auth-signout: file deletion when empty', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('deletes auth.json entirely when scrub leaves it empty', () => {
+        // Pure signin file with no legacy bookkeeping keys. After scrub
+        // there is nothing left worth keeping.
+        writeAuthToken({ token: 'token-xyz-abcdef', email: 'user@example.com' });
+        assert.ok(fs.existsSync(authFilePath()));
+
+        const result = removeAuthToken();
+        assert.equal(result.changed, true);
+        assert.equal(result.deleted, true);
+        assert.equal(result.email, 'user@example.com');
+        assert.ok(!fs.existsSync(authFilePath()), 'auth.json should be deleted when empty after scrub');
+    });
+
+    it('does NOT delete auth.json when bookkeeping keys remain', () => {
+        const legacy = { configured: true, tools: ['github'] };
+        fs.writeFileSync(authFilePath(), JSON.stringify(legacy, null, 2));
+        writeAuthToken({ token: 'token-xyz-abcdef' });
+
+        const result = removeAuthToken();
+        assert.equal(result.deleted, false);
+        assert.ok(fs.existsSync(authFilePath()));
+    });
+});
+
+describe('lib/auth-signout: file permissions', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('preserves mode 0600 after scrub (file kept)', () => {
+        // Set up signed-in + legacy bookkeeping so file survives scrub.
+        const legacy = { configured: true, tools: ['github'] };
+        fs.writeFileSync(authFilePath(), JSON.stringify(legacy, null, 2));
+        writeAuthToken({ token: 'token-xyz-abcdef' });
+
+        // Sanity: file is mode 0600 from signin.
+        const beforeMode = fs.statSync(authFilePath()).mode & 0o7777;
+        assert.equal(beforeMode, 0o600);
+
+        removeAuthToken();
+        const afterMode = fs.statSync(authFilePath()).mode & 0o7777;
+        assert.equal(afterMode, 0o600, `expected 0600 after scrub, got 0o${afterMode.toString(8)}`);
+    });
+});
+
+describe('lib/auth-signout: atomic write', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('does not leave the .tmp file behind after a successful scrub', () => {
+        const legacy = { configured: true };
+        fs.writeFileSync(authFilePath(), JSON.stringify(legacy, null, 2));
+        writeAuthToken({ token: 'token-xyz-abcdef' });
+
+        removeAuthToken();
+        const tmpPath = authFilePath() + '.tmp';
+        assert.ok(!fs.existsSync(tmpPath), '.tmp file should be renamed away');
+    });
+
+    it('does not leave the .tmp file behind when the file is deleted', () => {
+        writeAuthToken({ token: 'token-xyz-abcdef' });
+        removeAuthToken();
+        const tmpPath = authFilePath() + '.tmp';
+        assert.ok(!fs.existsSync(tmpPath));
+        assert.ok(!fs.existsSync(authFilePath()));
+    });
+});
+
+describe('lib/auth-signout: idempotency', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('second signout after the first is a no-op', () => {
+        writeAuthToken({ token: 'token-xyz-abcdef', email: 'user@example.com' });
+
+        const first = removeAuthToken();
+        assert.equal(first.changed, true);
+
+        const second = removeAuthToken();
+        assert.equal(second.changed, false);
+        assert.equal(second.deleted, false);
+        assert.equal(second.email, '');
+    });
+});
+
+describe('lib/auth-signout: authFilePath / readExistingAuth', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('authFilePath returns <DELIMIT_HOME>/auth.json', () => {
+        assert.equal(authFilePath(), path.join(tmpHome, AUTH_FILE_BASENAME));
+    });
+
+    it('readExistingAuth returns {} when the file is missing', () => {
+        assert.deepEqual(readExistingAuth(authFilePath()), {});
+    });
+
+    it('readExistingAuth returns {} for malformed JSON', () => {
+        fs.writeFileSync(authFilePath(), '{ not json');
+        assert.deepEqual(readExistingAuth(authFilePath()), {});
+    });
+
+    it('readExistingAuth returns the parsed object for valid JSON', () => {
+        fs.writeFileSync(authFilePath(), JSON.stringify({ a: 1, b: 'two' }));
+        assert.deepEqual(readExistingAuth(authFilePath()), { a: 1, b: 'two' });
+    });
+
+    it('readExistingAuth returns {} for non-object JSON (array, primitive)', () => {
+        fs.writeFileSync(authFilePath(), JSON.stringify(['a']));
+        assert.deepEqual(readExistingAuth(authFilePath()), {});
+    });
+});

--- a/tests/migration-2092-banner.test.js
+++ b/tests/migration-2092-banner.test.js
@@ -1,0 +1,379 @@
+/**
+ * LED-2095: tests for lib/migration-2092-banner.js — one-time migration
+ * banner shown to existing Free-tier users with BYOK deliberation
+ * configured. Surfaces the LED-2092 / LED-2093 gateway change (Free-tier
+ * BYOK deliberation is now operationally ephemeral).
+ *
+ * Locks the contract that:
+ *   - banner triggers for Free + BYOK users on first call
+ *   - banner does NOT trigger for Pro / Premium / Enterprise users
+ *   - banner does NOT trigger for Free users WITHOUT BYOK configured
+ *   - banner does NOT trigger when the flag file already exists
+ *   - flag file is written on trigger and persists across calls
+ *   - banner copy matches the locked snapshot (no em-dashes, no founder
+ *     identity strings, includes the pricing URL)
+ *   - read errors on models.json / license.json fail closed (no banner)
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+    FLAG_FILE_BASENAME,
+    flagFilePath,
+    modelsConfigPath,
+    licenseFilePath,
+    hasByokConfigured,
+    hasProLicense,
+    hasShownBanner,
+    shouldShowBanner,
+    writeShownFlag,
+    bannerText,
+    maybeShowMigrationBanner,
+} = require('../lib/migration-2092-banner');
+
+const ORIG_DELIMIT_HOME = process.env.DELIMIT_HOME;
+const ORIG_NAMESPACE_ROOT = process.env.DELIMIT_NAMESPACE_ROOT;
+
+let tmpHome;
+
+function setupTmpHome() {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'delimit-migration-2092-test-'));
+    process.env.DELIMIT_HOME = tmpHome;
+    delete process.env.DELIMIT_NAMESPACE_ROOT;
+}
+
+function teardownTmpHome() {
+    try {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+    } catch {}
+    if (ORIG_DELIMIT_HOME === undefined) delete process.env.DELIMIT_HOME;
+    else process.env.DELIMIT_HOME = ORIG_DELIMIT_HOME;
+    if (ORIG_NAMESPACE_ROOT === undefined) delete process.env.DELIMIT_NAMESPACE_ROOT;
+    else process.env.DELIMIT_NAMESPACE_ROOT = ORIG_NAMESPACE_ROOT;
+}
+
+// Helpers -------------------------------------------------------------
+
+function writeModelsConfig(config) {
+    fs.writeFileSync(modelsConfigPath(), JSON.stringify(config, null, 2));
+}
+
+function writeLicense(license) {
+    fs.writeFileSync(licenseFilePath(), JSON.stringify(license, null, 2));
+}
+
+function writeByokFreeUser() {
+    writeModelsConfig({
+        grok: { enabled: true, api_key: 'xai-fake-key-1234', model: 'grok-4-0709' },
+    });
+    // No license.json — Free tier.
+}
+
+// Tests ---------------------------------------------------------------
+
+describe('lib/migration-2092-banner: banner copy', () => {
+    it('does NOT contain em-dashes (per LED-2095 brief)', () => {
+        const text = bannerText();
+        assert.ok(!text.includes('—'), 'banner must not contain em-dashes');
+        assert.ok(!text.includes('–'), 'banner must not contain en-dashes either');
+    });
+
+    it('does NOT contain founder identity strings', () => {
+        // Per feedback_no_jamsons_in_public_artifacts.md — no holdco /
+        // founder name strings in any user-facing artifact.
+        const text = bannerText().toLowerCase();
+        assert.ok(!text.includes('jamsons'));
+        assert.ok(!text.includes('holdings'));
+    });
+
+    it('mentions the pricing URL for the Pro upsell', () => {
+        assert.ok(bannerText().includes('delimit.ai/pricing'));
+    });
+
+    it('mentions the Free-tier ephemeral behavior', () => {
+        const text = bannerText();
+        assert.ok(/Free deliberations/i.test(text));
+        assert.ok(/stdout/i.test(text));
+        assert.ok(/ephemeral/i.test(text));
+    });
+
+    it('mentions that existing transcripts are preserved', () => {
+        assert.ok(bannerText().includes('~/.delimit/memory/deliberations/'));
+    });
+
+    it('matches the exact locked snapshot', () => {
+        const expected = [
+            '',
+            'Free deliberations now print to stdout only.',
+            '',
+            'Your existing transcripts under ~/.delimit/memory/deliberations/ are preserved.',
+            'New deliberations on Free tier are ephemeral by design.',
+            '',
+            'Pro turns every deliberation into a signed, replayable attestation',
+            'with 365-day retention: delimit.ai/pricing',
+            '',
+        ].join('\n');
+        assert.equal(bannerText(), expected);
+    });
+});
+
+describe('lib/migration-2092-banner: hasByokConfigured', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns false when models.json does not exist', () => {
+        assert.equal(hasByokConfigured(), false);
+    });
+
+    it('returns false when models.json is malformed', () => {
+        fs.writeFileSync(modelsConfigPath(), '{ not json');
+        assert.equal(hasByokConfigured(), false);
+    });
+
+    it('returns false when models.json is an empty object', () => {
+        writeModelsConfig({});
+        assert.equal(hasByokConfigured(), false);
+    });
+
+    it('returns false when no entries are enabled', () => {
+        writeModelsConfig({
+            grok: { enabled: false, api_key: 'xai-key', model: 'grok-4-0709' },
+        });
+        assert.equal(hasByokConfigured(), false);
+    });
+
+    it('returns false when an entry is enabled but has no api_key', () => {
+        writeModelsConfig({
+            grok: { enabled: true, api_key: '', model: 'grok-4-0709' },
+        });
+        assert.equal(hasByokConfigured(), false);
+    });
+
+    it('returns true when at least one entry is enabled with an api_key', () => {
+        writeModelsConfig({
+            grok: { enabled: true, api_key: 'xai-fake-key-1234', model: 'grok-4-0709' },
+        });
+        assert.equal(hasByokConfigured(), true);
+    });
+
+    it('returns true when ANY entry meets the bar (mixed config)', () => {
+        writeModelsConfig({
+            grok: { enabled: false, api_key: 'xai-key', model: 'grok-4-0709' },
+            gemini: { enabled: true, api_key: 'AIza-key', model: 'gemini-2.5-pro' },
+            openai: { enabled: true, api_key: '', model: 'gpt-4o' },
+        });
+        assert.equal(hasByokConfigured(), true);
+    });
+
+    it('returns false when models.json is a JSON array', () => {
+        fs.writeFileSync(modelsConfigPath(), JSON.stringify(['grok']));
+        assert.equal(hasByokConfigured(), false);
+    });
+});
+
+describe('lib/migration-2092-banner: hasProLicense', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns false when license.json does not exist', () => {
+        assert.equal(hasProLicense(), false);
+    });
+
+    it('returns false when license.json is malformed', () => {
+        fs.writeFileSync(licenseFilePath(), '{ broken');
+        assert.equal(hasProLicense(), false);
+    });
+
+    it('returns false when valid=false', () => {
+        writeLicense({ valid: false, tier: 'pro' });
+        assert.equal(hasProLicense(), false);
+    });
+
+    it('returns false when valid=true but tier is "free"', () => {
+        writeLicense({ valid: true, tier: 'free' });
+        assert.equal(hasProLicense(), false);
+    });
+
+    it('returns true for valid pro license', () => {
+        writeLicense({ valid: true, tier: 'pro' });
+        assert.equal(hasProLicense(), true);
+    });
+
+    it('returns true for valid premium license', () => {
+        writeLicense({ valid: true, tier: 'premium' });
+        assert.equal(hasProLicense(), true);
+    });
+
+    it('returns true for valid enterprise license', () => {
+        writeLicense({ valid: true, tier: 'enterprise' });
+        assert.equal(hasProLicense(), true);
+    });
+});
+
+describe('lib/migration-2092-banner: shouldShowBanner / trigger logic', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('triggers for Free + BYOK first time (all conditions met)', () => {
+        writeByokFreeUser();
+        assert.equal(shouldShowBanner(), true);
+    });
+
+    it('does NOT trigger for Pro users (tier=pro)', () => {
+        writeByokFreeUser();
+        writeLicense({ valid: true, tier: 'pro' });
+        assert.equal(shouldShowBanner(), false);
+    });
+
+    it('does NOT trigger for Premium users', () => {
+        writeByokFreeUser();
+        writeLicense({ valid: true, tier: 'premium' });
+        assert.equal(shouldShowBanner(), false);
+    });
+
+    it('does NOT trigger for Enterprise users', () => {
+        writeByokFreeUser();
+        writeLicense({ valid: true, tier: 'enterprise' });
+        assert.equal(shouldShowBanner(), false);
+    });
+
+    it('does NOT trigger for Free users WITHOUT BYOK', () => {
+        // No models.json at all.
+        assert.equal(shouldShowBanner(), false);
+    });
+
+    it('does NOT trigger for Free users with disabled BYOK entries', () => {
+        writeModelsConfig({
+            grok: { enabled: false, api_key: 'xai-key', model: 'grok-4-0709' },
+        });
+        assert.equal(shouldShowBanner(), false);
+    });
+
+    it('does NOT trigger when the flag file already exists', () => {
+        writeByokFreeUser();
+        // Pre-write the flag file.
+        writeShownFlag({ now: '2026-05-08T12:00:00.000Z', version: '4.5.13' });
+        assert.equal(shouldShowBanner(), false);
+    });
+});
+
+describe('lib/migration-2092-banner: writeShownFlag', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('writes the flag file with shown_at, version, and led', () => {
+        writeShownFlag({ now: '2026-05-08T12:00:00.000Z', version: '4.5.14' });
+        assert.ok(fs.existsSync(flagFilePath()));
+        const data = JSON.parse(fs.readFileSync(flagFilePath(), 'utf-8'));
+        assert.equal(data.shown_at, '2026-05-08T12:00:00.000Z');
+        assert.equal(data.version, '4.5.14');
+        assert.equal(data.led, 'LED-2095');
+    });
+
+    it('uses ISO8601 for shown_at when not overridden', () => {
+        writeShownFlag();
+        const data = JSON.parse(fs.readFileSync(flagFilePath(), 'utf-8'));
+        assert.match(data.shown_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+        assert.ok(!Number.isNaN(Date.parse(data.shown_at)));
+    });
+
+    it('creates DELIMIT_HOME if missing', () => {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+        writeShownFlag({ now: '2026-05-08T12:00:00.000Z', version: '4.5.14' });
+        assert.ok(fs.existsSync(tmpHome));
+        assert.ok(fs.existsSync(flagFilePath()));
+    });
+
+    it('uses tmp + rename (no .tmp left behind)', () => {
+        writeShownFlag();
+        const tmp = flagFilePath() + '.tmp';
+        assert.ok(!fs.existsSync(tmp));
+    });
+});
+
+describe('lib/migration-2092-banner: maybeShowMigrationBanner', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns shown=true with banner text on first qualifying call', () => {
+        writeByokFreeUser();
+        const result = maybeShowMigrationBanner({
+            now: '2026-05-08T12:00:00.000Z',
+            version: '4.5.14',
+        });
+        assert.equal(result.shown, true);
+        assert.equal(result.text, bannerText());
+        assert.ok(fs.existsSync(flagFilePath()));
+    });
+
+    it('returns shown=false on the second call (flag-file gates re-fire)', () => {
+        writeByokFreeUser();
+        const first = maybeShowMigrationBanner({
+            now: '2026-05-08T12:00:00.000Z',
+            version: '4.5.14',
+        });
+        assert.equal(first.shown, true);
+
+        const second = maybeShowMigrationBanner({
+            now: '2026-05-08T13:00:00.000Z',
+            version: '4.5.14',
+        });
+        assert.equal(second.shown, false);
+        assert.equal(second.text, '');
+    });
+
+    it('returns shown=false for Pro users without writing the flag', () => {
+        writeByokFreeUser();
+        writeLicense({ valid: true, tier: 'pro' });
+        const result = maybeShowMigrationBanner();
+        assert.equal(result.shown, false);
+        assert.equal(result.text, '');
+        // Flag file MUST NOT be written for Pro users — they have not
+        // seen the banner and should not have it suppressed if they
+        // ever downgrade to Free in the future.
+        assert.ok(!fs.existsSync(flagFilePath()));
+    });
+
+    it('returns shown=false for Free users without BYOK and does not write the flag', () => {
+        // No models.json, no license.json.
+        const result = maybeShowMigrationBanner();
+        assert.equal(result.shown, false);
+        assert.ok(!fs.existsSync(flagFilePath()));
+    });
+
+    it('preserves the flag file across re-runs (file is the source of truth)', () => {
+        writeByokFreeUser();
+        maybeShowMigrationBanner({
+            now: '2026-05-08T12:00:00.000Z',
+            version: '4.5.14',
+        });
+        const firstStat = fs.statSync(flagFilePath());
+
+        // Second call must NOT touch the flag file.
+        maybeShowMigrationBanner();
+        const secondStat = fs.statSync(flagFilePath());
+        assert.equal(firstStat.mtimeMs, secondStat.mtimeMs);
+    });
+});
+
+describe('lib/migration-2092-banner: hasShownBanner', () => {
+    beforeEach(setupTmpHome);
+    afterEach(teardownTmpHome);
+
+    it('returns false when the flag file is missing', () => {
+        assert.equal(hasShownBanner(), false);
+    });
+
+    it('returns true after writeShownFlag', () => {
+        writeShownFlag();
+        assert.equal(hasShownBanner(), true);
+    });
+
+    it('flag file basename is migration_2092.shown', () => {
+        assert.equal(FLAG_FILE_BASENAME, 'migration_2092.shown');
+    });
+});


### PR DESCRIPTION
## Summary

Two CLI-side follow-ups to delimit-gateway PR #131 (LED-2092 + LED-2093, merged 2026-05-08), which made Free-tier BYOK deliberation operationally ephemeral.

### LED-2106 — `delimit signout`

Convenience wrapper around `rm ~/.delimit/auth.json` that ONLY removes the OAuth-related keys written by `delimit signin` (LED-2100):

- `delimit_token`
- `access_token`
- `signed_in_at`
- `email`

Preserves every other key (`configured`, `timestamp`, `tools`) written by `delimit auth` / `lib/auth-setup.js`. If the post-scrub file has zero keys, it's deleted entirely (cleanest state). Atomic tmp+rename, mode 0600 preserved. Idempotent: prints `Not signed in.` and exits 0 when there's nothing to scrub.

### LED-2095 — Free-tier BYOK migration banner

One-time banner shown on the next deliberation-adjacent CLI call (`delimit deliberate`, `delimit models`) for users who:

1. Have `~/.delimit/models.json` with at least one enabled entry + `api_key` (BYOK), AND
2. Have no active Pro/Premium/Enterprise license, AND
3. Have not seen the banner yet (gated by `~/.delimit/migration_2092.shown`).

Surfaces the LED-2092 gateway change: Free-tier BYOK deliberations now print to stdout only — no persistent transcript, no signed attestation, no replay URL. Existing transcripts under `~/.delimit/memory/deliberations/` are preserved. Banner ends with the `delimit.ai/pricing` upsell.

Banner copy is locked (snapshot test), contains no em-dashes, no founder identity strings, and a clean Pro upsell line.

### Out of scope

The email side of LED-2095 (sending a migration notice via delimit-ui to authenticated BYOK users) is deferred to a follow-up. CLI banner alone closes the migration loop for the active user surface.

### Linked LEDs

- [LED-2092](https://github.com/delimit-ai/delimit-mcp-server) — gateway-side ephemeral Free-tier BYOK deliberation (already merged in delimit-gateway PR #131; reason this CLI banner exists)
- LED-2095 — this CLI migration banner
- LED-2100 — `delimit signin` precedent (atomic tmp+rename + mode 0600 reused here)
- LED-2106 — this `delimit signout` command

## Test plan

- [x] `npm test` passes (289/289 baseline, +62 new = 351 total all passing)
- [x] `node --test tests/auth-signout.test.js` passes (22/22)
- [x] `node --test tests/migration-2092-banner.test.js` passes (40/40)
- [x] Pre-push gate passes (`npm test` runs and clears)
- [x] Manual smoke: signin -> signout end-to-end deletes the file when no other keys present
- [x] Manual smoke: signin -> signout preserves `configured` / `timestamp` / `tools` when present
- [x] Manual smoke: signout when not signed in prints `Not signed in.` and exits 0
- [x] Manual smoke: migration banner fires on first `delimit deliberate` for Free + BYOK user, suppresses on second call
- [ ] Pro user (with valid license.json tier=pro) does not see the banner — verified via test, not manual
- [ ] Free user without BYOK does not see the banner — verified via test, not manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)