### PR TITLE
docs: surface cross-agent-handoff worked example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Every wrapped run emits a `delimit.attestation.v1` bundle: repo head before/afte
 
 ## See it in action
 
-Worked example, real OSS repo, every claim verifiable:
+Worked examples, real artifacts, every claim verifiable:
 
+- **[Cross-agent handoff: one artifact, four CLIs](https://delimit.ai/reports/cross-agent-handoff)**: structured session handoff between Claude Code, Codex, Cursor, and Gemini CLI through a single JSON record at `~/.delimit/sessions/`. Persistent context across sessions, same artifact across four CLIs.
 - **[cal.com v2 API attestation](https://delimit.ai/reports/cal-com-v2-attestation)**: full diff, signed verdict, replayable bundle. Runs the same chain you get on day one.
 
 For the schema and signing methodology behind every report, see **[delimit.ai/methodology/mcp-attestation](https://delimit.ai/methodology/mcp-attestation)**.


### PR DESCRIPTION
## Summary

Surfaces the cross-agent-handoff report (live at delimit.ai/reports/cross-agent-handoff, methodology at delimit.ai/methodology/cross-agent-handoff) on the bundle README.

## Diff

3 lines: 1 modified + 1 added.

\`\`\`
-Worked example, real OSS repo, every claim verifiable:
+Worked examples, real artifacts, every claim verifiable:

+- **[Cross-agent handoff: one artifact, four CLIs](https://delimit.ai/reports/cross-agent-handoff)**: structured session handoff between Claude Code, Codex, Cursor, and Gemini CLI through a single JSON record at ~/.delimit/sessions/. Persistent context across sessions, same artifact across four CLIs.
\`\`\`

## Scope

- No source-code changes
- No tool-count claim changes (per CLAUDE.md vocabulary governance)
- No canonical-copy edits (merge-gate framing preserved)
- No SHIFT-1 leakage (no founder identity / Jamsons strings)
- Singular → plural pluralization on the section lede

## Test plan

- [x] Worked example link target is live (delimit.ai/reports/cross-agent-handoff — confirmed shipped per session ledger LED-1361 / GOV-04FC3B6F)
- [x] Pre-push hook passed after local git config user.email cure (LED-2243 identity guard fired as designed when config was polluted; legitimate work cleared once config restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)