### PR TITLE
fix(hooks): bypass broken npx fallback in pre-commit/pre-push generator (LED-1207)

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -4629,9 +4629,19 @@ program
         const prePushPath = path.join(hooksDir, 'pre-push');
         const marker = '# delimit-governance-hook';
 
-        // Resolution order: local node_modules → global PATH → npx fallback.
-        // npx is last because it can fail with Arborist 'extraneous' errors
-        // when a project's node_modules / lockfile drift (LED-1248).
+        // Resolution order: local node_modules → global PATH →
+        // global node_modules direct → npx fallback.
+        //
+        // npx is the LAST resort because on some npm-arborist environments
+        // it crashes with "Cannot read properties of undefined (reading
+        // 'extraneous')" before reaching the CLI (LED-1207, LED-1248). That
+        // failure mode silently breaks the gate and forces --no-verify,
+        // which violates the no-silent-no-verify rule.
+        //
+        // The third tier (`node $(npm root -g)/delimit-cli/bin/delimit-cli.js`)
+        // catches the case where delimit-cli is globally installed but its bin
+        // shim isn't on PATH (npm-installed-but-symlink-missing, fresh CI
+        // containers, etc.) — bypassing npm/npx entirely.
         const preCommitHook = `#!/bin/sh
 ${marker}
 # Delimit API governance gate
@@ -4640,6 +4650,8 @@ if [ -x ./node_modules/.bin/delimit-cli ]; then
   ./node_modules/.bin/delimit-cli check --staged
 elif command -v delimit-cli >/dev/null 2>&1; then
   delimit-cli check --staged
+elif _delimit_global="$(npm root -g 2>/dev/null)/delimit-cli/bin/delimit-cli.js" && [ -f "$_delimit_global" ]; then
+  node "$_delimit_global" check --staged
 else
   npx delimit-cli check --staged
 fi
@@ -4653,6 +4665,8 @@ if [ -x ./node_modules/.bin/delimit-cli ]; then
   ./node_modules/.bin/delimit-cli check --base origin/main
 elif command -v delimit-cli >/dev/null 2>&1; then
   delimit-cli check --base origin/main
+elif _delimit_global="$(npm root -g 2>/dev/null)/delimit-cli/bin/delimit-cli.js" && [ -f "$_delimit_global" ]; then
+  node "$_delimit_global" check --base origin/main
 else
   npx delimit-cli check --base origin/main
 fi


### PR DESCRIPTION
## Summary

`delimit hooks install` generates a fallback chain that ends in `npx delimit-cli`. On some npm-arborist environments, that npx invocation crashes with *Cannot read properties of undefined (reading 'extraneous')* before reaching the CLI — silently breaking the gate and forcing `--no-verify`.

## Reproduction (this machine, 2026-05-15)

```
$ cd /home/delimit/npm-delimit
$ npx delimit-cli check --staged
npm error Cannot read properties of undefined (reading 'extraneous')
```

(`delimit-cli check --staged` from PATH works fine; only the npx layer is broken.)

## Fix

Insert a 3rd tier between PATH and npx that bypasses npm/npx entirely:

```sh
elif _delimit_global="$(npm root -g 2>/dev/null)/delimit-cli/bin/delimit-cli.js" && [ -f "$_delimit_global" ]; then
  node "$_delimit_global" check --staged
```

Catches the case where delimit-cli is globally installed but its bin shim isn't on PATH (npm-installed-but-symlink-missing, fresh CI containers, etc.). npx stays as the last-resort fallback for ephemeral environments where neither local nor global install exists.

## Verification
- [x] `$(npm root -g)/delimit-cli/bin/delimit-cli.js` exists and is executable on this machine
- [x] `node "$(npm root -g)/delimit-cli/bin/delimit-cli.js" check --staged` returns exit 0 with expected output
- [x] npm-delimit full test suite: 302 passed, 0 failed
- [x] npm-delimit's own `.git/hooks/pre-commit` (hand-written for LED-1207 — uses `node $(dirname $0)/../../bin/delimit-cli.js` directly) unchanged; this generator fix is for OTHER repos that run `delimit hooks install`

## Related
LED-1207 (the work tracker), LED-1248 (prior arborist incident referenced in original code comment)