### PR TITLE
fix(setup): LED-1564 — pin pytest into the venv install chain

### DIFF
--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -258,18 +258,22 @@ async function main() {
         const venvPy = fs.existsSync(venvPython) ? venvPython : venvPythonWin;
         if (fs.existsSync(reqFile)) {
             execSync(`"${venvPy}" -m pip install --quiet -r "${reqFile}" 2>/dev/null`, { stdio: 'pipe' });
+            // LED-1564: even when reqFile exists, ensure pytest is present.
+            // Older reqFiles (pre-2026-05-22) didn't list it; without pytest
+            // the delimit_test_smoke deploy-gate step fails to run cleanly.
+            execSync(`"${venvPy}" -m pip install --quiet pytest 2>/dev/null`, { stdio: 'pipe' });
         } else {
-            execSync(`"${venvPy}" -m pip install --quiet fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 2>/dev/null`, { stdio: 'pipe' });
+            execSync(`"${venvPy}" -m pip install --quiet fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 pytest 2>/dev/null`, { stdio: 'pipe' });
         }
         python = venvPy;  // Use venv python for MCP config
         await logp(`  ${green('✓')} Python dependencies installed (isolated venv)`);
     } catch {
         log(`  ${yellow('!')} venv install failed — trying global pip`);
         try {
-            execSync(`${python} -m pip install --quiet fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 2>/dev/null`, { stdio: 'pipe' });
+            execSync(`${python} -m pip install --quiet fastmcp==3.1.0 pyyaml==6.0.3 pydantic==2.12.5 packaging==26.0 pytest 2>/dev/null`, { stdio: 'pipe' });
             await logp(`  ${green('✓')} Python dependencies installed (global)`);
         } catch {
-            log(`  ${yellow('!')} pip install failed — run manually: pip install fastmcp pyyaml pydantic packaging`);
+            log(`  ${yellow('!')} pip install failed — run manually: pip install fastmcp pyyaml pydantic packaging pytest`);
         }
     }
 


### PR DESCRIPTION
## Summary
Pin \`pytest\` into the npm-delimit setup script so fresh installs provision \`~/.delimit/venv/\` with pytest available. Without it, \`delimit_test_smoke\` falls back to \`sys.executable\` (= the venv Python) which then can't \`-m pytest\` and the deploy-gate step fails.

Caught end of 2026-05-22 session — founder had to manually \`python3 -m pytest\` against the gateway worktree because the MCP runner venv was missing pytest.

## Three patches (all in \`bin/delimit-setup.js\`)
1. **Inline-list fallback** (no \`reqFile\`): added \`pytest\` to the install list.
2. **\`reqFile\` branch** (when \`~/.delimit/server/requirements.txt\` exists): explicit \`pip install pytest\` after the reqFile install, so older reqFiles don't have to be manually edited. Idempotent.
3. **Global-pip fallback** (venv install failed): added \`pytest\` + updated the manual-fallback hint.

## Why
\`delimit_test_smoke\`'s pytest framework path (\`backends/tools_real.py\` test_smoke) resolves \`sys.executable\` to pick the Python that runs the tests. When the MCP server runs from the venv (common case), \`sys.executable\` IS the venv Python — and \`python -m pytest\` fails without pytest installed there.

## Diff
\`bin/delimit-setup.js\` only — +7 / -3 lines.

## Test plan
- [x] No code-behavior change for existing installs that already have pytest.
- [x] Pre-push gate green
- [ ] Live verification: next fresh \`delimit-cli setup\` (post-4.6.2 publish) provisions \`~/.delimit/venv/bin/pytest\`.

## No publish under this PR
Install-time fix kicks in on fresh installs of the next functional release. Existing 4.6.1 tarball unaffected. Local recovery on this machine already done (\`/root/.delimit/venv/bin/pip install pytest\` + \`~/.delimit/server/requirements.txt\` updated).

## Out-of-scope follow-up (separate PR if needed)
Runtime fallback in \`delimit-gateway/ai/backends/tools_real.py\` test_smoke — try \`python3 -m pytest\` when the resolved Python lacks pytest. Defense-in-depth; not required if the install-time pin is consistently applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)