### PR TITLE
fix(ci): make security-check.sh re-entrancy-safe under npm publish (publish-blocker)

### DIFF
--- a/scripts/security-check.sh
+++ b/scripts/security-check.sh
@@ -8,11 +8,32 @@ echo "🔍 Delimit pre-publish security scan..."
 
 FAIL=0
 
-# Pack to temp and scan the actual tarball contents
+# Reconstruct the EXACT set of files npm would publish, then scan them.
+#
+# We deliberately avoid `npm pack` writing a tarball here: when this script
+# runs inside `npm publish` (via prepublishOnly), a nested `npm pack` is
+# unreliable on npm 10.x — it reports a tarball name but persists no file
+# (not to --pack-destination, not to CWD), so the old `ls "$TMPDIR"/*.tgz`
+# failed with exit 2 and blocked every publish. `npm pack --dry-run --json`
+# only ENUMERATES the shipped files (honoring package.json "files" and the
+# "!"-exclusions) and never writes a tarball, so it is re-entrancy-safe.
+# We copy those exact files into TMPDIR/package/ and keep the proven scan
+# blocks below byte-for-byte.
 TMPDIR=$(mktemp -d)
-npm pack --pack-destination "$TMPDIR" --quiet 2>/dev/null
-TARBALL=$(ls "$TMPDIR"/*.tgz)
-tar -xzf "$TARBALL" -C "$TMPDIR"
+mkdir -p "$TMPDIR/package"
+npm pack --dry-run --json 2>/dev/null \
+  | node -e 'const d=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write((d[0].files||[]).map(f=>f.path).join("\n"))' \
+  | while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      mkdir -p "$TMPDIR/package/$(dirname "$f")"
+      cp "$f" "$TMPDIR/package/$f" 2>/dev/null || true
+    done
+
+if [ -z "$(find "$TMPDIR/package" -type f -print -quit)" ]; then
+    echo "❌ security-check: could not enumerate shipped files (npm pack --dry-run --json returned nothing)"
+    rm -rf "$TMPDIR"
+    exit 1
+fi
 
 # 1. Credential patterns
 echo -n "  Credentials... "


### PR DESCRIPTION
## Why
The v4.7.0 publish **dry-run's publish job failed** in `prepublishOnly` → `security-check.sh`:
```
🔍 Delimit pre-publish security scan...
delimit-cli-4.7.0.tgz
ls: cannot access '/tmp/tmp.XXX/*.tgz': No such file or directory
npm error code 2
```
A nested `npm pack` (during `npm publish`) on npm 10.x reports a tarball name but **persists no file** — so the `ls $TMPDIR/*.tgz` failed and blocked the publish. This fires on a **real** publish too (prepublishOnly runs for both), so it's a hard blocker.

## Fix
Enumerate the shipped file set with `npm pack --dry-run --json` (write-free, honors `files[]`/exclusions), copy those exact files into `TMPDIR/package/`, and keep the proven grep scan blocks **byte-for-byte**. No tarball is written during publish.

## Verification (local)
- Standalone: all clean, exit 0.
- **Negative test**: injected `jamsonsholdings` into a shipped file → scan correctly **FAILED** (gate intact), then reverted.
- `npm publish --dry-run`: now passes nested through prepublishOnly to the publish step.

`scripts/` is excluded from `files[]` — not a shipped/customer-facing change. npm publish stays held until this lands + a clean CI dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)