### PR TITLE
ci(publish): switch npm publish to OIDC Trusted Publishing (no token)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,19 +160,28 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install 'nuitka==2.5.9'
 
+      - name: Upgrade npm for OIDC trusted publishing (>= 11.5.1)
+        # Node 20 ships npm 10.x, which does not understand the OIDC trusted-
+        # publishing handshake. npm >= 11.5.1 is required. We upgrade npm only
+        # (rather than bumping the Node version) to leave the Nuitka/license_core
+        # build environment untouched.
+        run: npm install -g npm@latest
+
       - name: Publish (dry run)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
         working-directory: npm-delimit
         run: npm publish --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
+        # Trusted Publishing (OIDC): no NODE_AUTH_TOKEN. Auth comes from the
+        # id-token: write OIDC handshake against the npm trusted-publisher config
+        # for this repo+workflow. Provenance is generated automatically; we keep
+        # --provenance explicit. REQUIRES a trusted publisher configured on
+        # npmjs.com (delimit-cli -> GitHub Actions, repo delimit-ai/delimit-mcp-server,
+        # workflow publish.yml) BEFORE the next publish, or auth fails.
         if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
         working-directory: npm-delimit
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Verify published version
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,8 +164,9 @@ jobs:
         # Node 20 ships npm 10.x, which does not understand the OIDC trusted-
         # publishing handshake. npm >= 11.5.1 is required. We upgrade npm only
         # (rather than bumping the Node version) to leave the Nuitka/license_core
-        # build environment untouched.
-        run: npm install -g npm@latest
+        # build environment untouched. Pinned to ^11 (not @latest) so a future
+        # npm major can't silently change CI publish behavior; 11.x is >= 11.5.1.
+        run: npm install -g npm@^11
 
       - name: Publish (dry run)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'


### PR DESCRIPTION
## Why
The token-based CI publish failed on v4.7.0 — `E404 PUT https://registry.npmjs.org/delimit-cli`, the `NPM_TOKEN` secret (set 2026-04-10) is expired/insufficient. v4.7.0 shipped via local `npm publish` **without sigstore provenance** (LED-2301). This moves publishing to **npm Trusted Publishing (OIDC)** — no long-lived token, and provenance is generated automatically on every CI publish.

## Change (publish job only)
- Add `npm install -g npm@latest` — Node 20 ships npm 10.x, but OIDC trusted publishing requires **npm ≥ 11.5.1**. Upgrading npm (vs bumping Node) keeps the Nuitka/license_core build env untouched.
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from both publish steps — auth now comes from the OIDC handshake.
- `id-token: write` is already granted at workflow level; `--provenance` kept explicit.

## ⚠️ Required precondition (founder, on npmjs.com)
Before the **next** publish, configure a Trusted Publisher for `delimit-cli`:
**npmjs.com → delimit-cli → Settings → Trusted Publisher → GitHub Actions**, org/repo `delimit-ai/delimit-mcp-server`, workflow filename `publish.yml`. Without it, OIDC auth fails (no token fallback remains). The `NPM_TOKEN` secret can be deleted once a CI publish is verified green.

## Verification
YAML validates; `id-token: write` present; no `NODE_AUTH_TOKEN`/`NPM_TOKEN` references remain (comment only). Full OIDC path can only be verified by a real CI publish after the npmjs.com config — tracked in LED-2301.

Refs: canonical workflow per [npm docs](https://docs.npmjs.com/trusted-publishers/) and [npm OIDC GA](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)