### PR TITLE
release: v4.7.1 — verify OIDC trusted-publishing pipeline (provenance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 
+## [4.7.1] - 2026-06-03
+
+Release-infrastructure update. No functional changes to the package versus 4.7.0.
+
+### Changed
+
+- Published via **npm Trusted Publishing (OIDC)** from GitHub Actions — this
+  release carries a **sigstore provenance attestation** (the 4.7.0 build was
+  published manually and did not). Future releases publish tokenlessly with
+  provenance.
+
+The free `delimit seal-verify` command and `delimit_seal_verify` MCP tool from
+4.7.0 are unchanged.
+
+
 ## [4.7.0] - 2026-06-03
 
 Feature release: fold the open-core Delimit Seal verifier into delimit-cli.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## What
Patch bump 4.7.0 → 4.7.1 to cut the **first release via npm Trusted Publishing (OIDC)**, carrying a **sigstore provenance attestation** that the manually-published 4.7.0 lacked.

- **No functional package changes** vs 4.7.0 — `.github/` (the only main change since 4.7.0) isn't in the npm bundle. Same `seal-verify` feature, now provenance-attested.
- Founder has configured the npmjs.com trusted publisher (delimit-cli → GitHub Actions, this repo, `publish.yml`).

## Gates
security_audit clean (0 critical/0 secrets; evidence ev-1780542184), test_smoke fail 0. After merge: tag `v4.7.1` → `publish.yml` publishes via OIDC + auto GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)