### PR TITLE
ci(publish): drop registry-url so OIDC trusted publishing works (v4.7.1 E404 fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,7 +133,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          # Intentionally NO registry-url: setup-node@v4 + registry-url writes a
+          # temp .npmrc with `always-auth` and a DUMMY NODE_AUTH_TOKEN placeholder
+          # (XXXXX-XXXXX-XXXXX-XXXXX) when no real token env is provided. npm then
+          # authenticates with that garbage token and OIDC trusted publishing is
+          # never attempted -> E404 on publish. npm defaults to registry.npmjs.org
+          # already, and OIDC auth needs no .npmrc token. (v4.7.1 first attempt.)
 
       - name: Install dependencies
         working-directory: npm-delimit


### PR DESCRIPTION
## Why
The v4.7.1 OIDC publish failed: `E404 PUT .../delimit-cli`. Log root cause — `actions/setup-node@v4` + `registry-url` writes a temp `.npmrc` with `always-auth` and a **dummy `NODE_AUTH_TOKEN` placeholder** (`XXXXX-XXXXX-XXXXX-XXXXX`) when no token env is set. npm authenticates with that garbage token instead of falling through to OIDC → 404. (Provenance signed fine — separate id-token use, so OIDC itself works.)

## Fix
Remove `registry-url` from the publish job's setup-node. npm defaults to `registry.npmjs.org`; with no `.npmrc` token, it uses OIDC trusted publishing. `npm@^11` + `id-token: write` unchanged. Validate job (no registry-url) unaffected.

## Verify
After merge, re-run the publish (workflow_dispatch dry_run=false, or re-tag) — expect tokenless OIDC auth + provenance, 4.7.1 live. Tracked LED-2301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)