### PR TITLE
release: v4.7.2 — tool-usage telemetry fix + dormant-tool activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 
+## [4.7.2] - 2026-06-04
+
+### Fixed
+
+- **Tool-usage telemetry now persists.** `record_call` previously only kept an
+  in-memory per-session counter that vanished on restart, so tool utilization
+  was unobservable. It now appends every call to `~/.delimit/tool_usage.jsonl`
+  (crash-safe, append-only), making utilization and dormancy measurable.
+
+### Added
+
+- **`delimit_toolcard_cache action="usage"`** — durable tool-utilization +
+  dormancy report (per-tool call counts, `last_seen`, and registered tools never
+  called).
+- Additive next-step suggestions wiring under-surfaced tools into the governance
+  loop: `lint → impact`, `agent_dispatch → agent_link`, `deploy_verify →
+  seal_verify`, `evidence_collect → seal_verify`, `os_plan → os_gates`.
+
+Purely additive — no tool signature or behavior changed. Published via OIDC
+trusted publishing with provenance.
+
+
 ## [4.7.1] - 2026-06-03
 
 Release-infrastructure update. No functional changes to the package versus 4.7.0.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## What
- **Fix:** `record_call` now persists tool-usage to `~/.delimit/tool_usage.jsonl` (was in-memory-only → utilization was unobservable).
- **Add:** `delimit_toolcard_cache action=usage` (durable utilization + dormancy report); additive next-step chains surfacing `impact`, `agent_link`, `seal_verify`, `os_gates` in the governance loop.
- Gateway code (`toolcard_cache.py`, `server.py`) ships via CI `sync-gateway` from delimit-gateway main (`d905bd4` + `40963df`). Purely additive — no signature/behavior change.

## Gates
security_audit clean (0 critical/0 secrets; evidence ev-1780548607), test_smoke fail 0. Activation plan deliberated unanimous (LED-1693). After merge: tag `v4.7.2` → OIDC publish (provenance) + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)