### PR TITLE
release: v4.7.3 — docs/metadata: min-privilege README on npm + 28-type correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 
+## [4.7.3] - 2026-06-04
+
+Docs + metadata release. No functional changes to the package.
+
+### Changed
+
+- npm README now carries the **"Adopt with minimum privilege"** section
+  (phase-1 read-only tool allowlist, Action SHA-pinning, BYOK vault guidance)
+  that previously only rendered on GitHub.
+- Detection-engine claims corrected to **28 change types (17 breaking,
+  11 non-breaking)** — adds `field_requirement_relaxed` (context-aware
+  severity) to the documented table.
+- `server.json` (MCP registry metadata) version brought current.
+
+
 ## [4.7.2] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ When installed into your AI coding assistant, Delimit provides tools across two 
 
 ## What It Detects
 
-27 change types (17 breaking, 10 non-breaking) -- deterministic rules, not AI inference. Same input always produces the same result.
+28 change types (17 breaking, 11 non-breaking) -- deterministic rules, not AI inference. Same input always produces the same result.
 
 ### Breaking Changes
 
@@ -362,6 +362,7 @@ When installed into your AI coding assistant, Delimit provides tools across two 
 | 25 | `security_added` | API key security scheme added |
 | 26 | `deprecated_added` | `GET /v1/users` marked as deprecated |
 | 27 | `default_changed` | Default value for `page_size` changed from 10 to 20 |
+| 28 | `field_requirement_relaxed` | Required field `nickname` became optional (context-aware severity) |
 
 ---
 
@@ -401,7 +402,7 @@ rules:
 
 **How does this compare to Obsidian Mind?**
 
-Obsidian Mind is a great Obsidian vault template for Claude Code users who want persistent memory via markdown files. Delimit takes a different approach: it's an MCP server that works across Claude Code, Codex, Gemini CLI, and Cursor. Your memory, ledger, and governance travel with you when you switch models. Delimit also adds API governance (27-type breaking change detection), CI gates, git hooks, and policy enforcement that Obsidian Mind doesn't cover. Use Obsidian Mind if you're all-in on Claude + Obsidian. Use Delimit if you switch between models or need governance.
+Obsidian Mind is a great Obsidian vault template for Claude Code users who want persistent memory via markdown files. Delimit takes a different approach: it's an MCP server that works across Claude Code, Codex, Gemini CLI, and Cursor. Your memory, ledger, and governance travel with you when you switch models. Delimit also adds API governance (28-type breaking change detection), CI gates, git hooks, and policy enforcement that Obsidian Mind doesn't cover. Use Obsidian Mind if you're all-in on Claude + Obsidian. Use Delimit if you switch between models or need governance.
 
 **Does this work without Claude Code?**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/delimit-ai/delimit-mcp-server",
     "source": "github"
   },
-  "version": "4.5.13",
+  "version": "4.7.3",
   "websiteUrl": "https://delimit.ai",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "delimit-cli",
-      "version": "4.5.13",
+      "version": "4.7.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Docs+metadata only — no code. Ships the min-privilege README section to npm, corrects 27→28 change types (engine-verified), fixes server.json registry version (4.5.13→4.7.3). Phase 3 of LED-1695 (unanimous deliberation + founder 'launch all phases'). Gates: security_audit 0 findings, test_smoke fail 0. After merge: tag v4.7.3 → OIDC publish + Seal receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)