### PR TITLE
v4.7.8 — portable gateway paths (fix hardcoded dev-path defaults)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 
+## [4.7.8] - 2026-06-09
+
+### Fixed
+
+- **Portable gateway paths.** ~8 functional defaults hardcoded the developer's
+  `/home/delimit/delimit-gateway` checkout, which doesn't exist on customer
+  installs (agent reaping, dispatch, loop engine, continuity, content
+  grounding). They now resolve the gateway repo root portably via a new
+  `_paths` resolver (`DELIMIT_GATEWAY_REPO`/`DELIMIT_GATEWAY_ROOT` env override
+  → `__file__`-relative root), with no behavior change where the dev path was
+  already correct.
+
 ## [4.7.7] - 2026-06-09
 
 `delimit chat` resilience.

--- a/gateway/ai/_paths.py
+++ b/gateway/ai/_paths.py
@@ -1,0 +1,39 @@
+"""Portable gateway-path resolution (LED-1715).
+
+The gateway repo root used to be hardcoded as the founder's dev path
+(``/home/delimit/delimit-gateway``) in ~8 functional defaults. That works on
+the founder's machine (the path exists) but breaks on customer installs.
+
+This module resolves the gateway repo root portably:
+  1. An explicit env override (``DELIMIT_GATEWAY_REPO`` or the older
+     ``DELIMIT_GATEWAY_ROOT`` alias) wins, for containers/CI runners that
+     relocate the checkout.
+  2. Otherwise, fall back to ``__file__``-relative resolution: this file lives
+     at ``<gateway repo root>/ai/_paths.py``, so ``parent.parent`` is the repo
+     root on ANY machine. On the founder's box this still resolves to
+     ``/home/delimit/delimit-gateway`` — zero behavior change.
+
+Keep this module dependency-free (stdlib only) so it can be imported from
+anywhere without circular-import risk.
+"""
+
+import os
+from pathlib import Path
+
+# Env var names honored, in priority order. DELIMIT_GATEWAY_REPO is the
+# canonical name used by content_grounding; DELIMIT_GATEWAY_ROOT is the alias
+# used by continuity.py / inbox_daemon.py (LED-2107). Both are preserved.
+_ENV_VARS = ("DELIMIT_GATEWAY_REPO", "DELIMIT_GATEWAY_ROOT")
+
+
+def gateway_repo() -> str:
+    """Return the gateway repo root as a string, portably."""
+    for var in _ENV_VARS:
+        val = os.environ.get(var)
+        if val:
+            return val
+    # ai/_paths.py -> ai/ -> <gateway repo root>
+    return str(Path(__file__).resolve().parent.parent)
+
+
+GATEWAY_REPO = gateway_repo()

--- a/gateway/ai/content_grounding/build.py
+++ b/gateway/ai/content_grounding/build.py
@@ -37,7 +37,9 @@ logger = logging.getLogger("delimit.ai.content_grounding")
 # Default paths — overridable via env for testing.
 LEDGER_DIR = Path(os.environ.get("DELIMIT_LEDGER_DIR", str(Path.home() / ".delimit" / "ledger")))
 ATTESTATIONS_DIR = Path(os.environ.get("DELIMIT_ATTESTATIONS_DIR", str(Path.home() / ".delimit" / "attestations")))
-GATEWAY_REPO = Path(os.environ.get("DELIMIT_GATEWAY_REPO", "/home/delimit/delimit-gateway"))
+# LED-1715: portable gateway root (env override or __file__-relative), not a dev-path literal.
+from ai._paths import GATEWAY_REPO as _GATEWAY_REPO
+GATEWAY_REPO = Path(_GATEWAY_REPO)
 GROUNDING_OUT = Path(os.environ.get("DELIMIT_GROUNDING_OUT", str(Path.home() / ".delimit" / "content" / "grounding")))
 
 

--- a/gateway/ai/content_grounding/features.py
+++ b/gateway/ai/content_grounding/features.py
@@ -40,7 +40,9 @@ from .consume import FEATURES_FILE
 
 logger = logging.getLogger("delimit.ai.content_grounding.features")
 
-GATEWAY_ROOT = Path(os.environ.get("DELIMIT_GATEWAY_REPO", "/home/delimit/delimit-gateway"))
+# LED-1715: portable gateway root (env override or __file__-relative), not a dev-path literal.
+from ai._paths import GATEWAY_REPO as _GATEWAY_REPO
+GATEWAY_ROOT = Path(_GATEWAY_REPO)
 NPM_BIN = Path(os.environ.get("DELIMIT_CLI_BIN", "/home/delimit/npm-delimit/bin/delimit-cli.js"))
 
 

--- a/gateway/ai/continuity.py
+++ b/gateway/ai/continuity.py
@@ -25,6 +25,8 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from ai._paths import GATEWAY_REPO
+
 logger = logging.getLogger("delimit.continuity")
 
 def _resolve_delimit_home() -> Path:
@@ -429,12 +431,8 @@ def _check_for_leaks(namespace_root: str) -> list:
 
     # Check 3: verify .gitignore coverage in the gateway repo
     # LED-2107: env-resolved so containers/CI runners outside ~/delimit-gateway work.
-    gateway_root = Path(
-        os.environ.get(
-            "DELIMIT_GATEWAY_ROOT",
-            "/home/delimit/delimit-gateway",
-        )
-    )
+    # LED-1715: portable fallback (__file__-relative) instead of a dev-path literal.
+    gateway_root = Path(GATEWAY_REPO)
     gateway_gitignore = gateway_root / ".gitignore"
     if gateway_gitignore.exists():
         content = gateway_gitignore.read_text()

--- a/gateway/ai/dispatch_gate.py
+++ b/gateway/ai/dispatch_gate.py
@@ -34,12 +34,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Optional
 
+from ai._paths import GATEWAY_REPO
+
 logger = logging.getLogger(__name__)
 
 # Default repos to search. Discovered at runtime first via the venture
 # registry; this list is the safety net if discovery returns nothing.
+# LED-1715: gateway root is portable (env / __file__-relative), not a dev path.
 DEFAULT_REPOS = (
-    "/home/delimit/delimit-gateway",
+    GATEWAY_REPO,
     "/home/delimit/delimit-action",
     "/home/delimit/npm-delimit",
     "/home/delimit/delimit-ui",

--- a/gateway/ai/loop_engine.py
+++ b/gateway/ai/loop_engine.py
@@ -19,6 +19,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ai._paths import GATEWAY_REPO
+
 logger = logging.getLogger("delimit.ai.loop_engine")
 
 # ── Configuration ────────────────────────────────────────────────────
@@ -1019,7 +1021,7 @@ def _act_auto_build(task: Dict[str, Any], ctx: Dict[str, str]) -> Dict[str, Any]
     task_id = task.get("id", "task")
     title = task.get("title", "")
     desc = task.get("description", "")
-    project_path = ctx.get("path", "/home/delimit/delimit-gateway")
+    project_path = ctx.get("path", GATEWAY_REPO)  # LED-1715: portable default
 
     instruction = f"Implement build task {task_id}: {title}\n\nGoal: {desc}\n\nUpdate the code but DO NOT COMMIT. I will handle the commit."
 
@@ -1289,7 +1291,7 @@ def run_governed_iteration(session_id: str, hardening: Optional[Any] = None) -> 
 
     
     # 0. Reap finished agent tasks (Plan-C)
-    reaped = ai.reaper.reap_agent_tasks(project_path=str(ctx["path"]) if "ctx" in locals() else "/home/delimit/delimit-gateway")
+    reaped = ai.reaper.reap_agent_tasks(project_path=str(ctx["path"]) if "ctx" in locals() else GATEWAY_REPO)  # LED-1715: portable default
     if reaped:
         logger.info("Reaped %d finished tasks", len(reaped))
     # 1. Load Session & Check Safeguards

--- a/gateway/ai/reaper.py
+++ b/gateway/ai/reaper.py
@@ -5,12 +5,18 @@ import time
 import os
 import re
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
+
+from ai._paths import GATEWAY_REPO
 
 logger = logging.getLogger("delimit.reaper")
 
-def reap_agent_tasks(project_path: str = "/home/delimit/delimit-gateway") -> List[str]:
+def reap_agent_tasks(project_path: Optional[str] = None) -> List[str]:
     """Reap completed agent arms by checking for commits and merging."""
+    # LED-1715: portable default. None -> env-resolved / __file__-relative
+    # gateway root (was a hardcoded dev path that broke customer installs).
+    if project_path is None:
+        project_path = GATEWAY_REPO
     from ai.agent_dispatch import get_agent_status, complete_task
     from ai.ledger_manager import update_item
     

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.7.7",
+  "version": "4.7.8",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## v4.7.8 — portable gateway paths (LED-1715)
~8 functional defaults hardcoded `/home/delimit/delimit-gateway` (the dev checkout) — works on the founder's box, breaks on customer installs (reaper, dispatch_gate, loop_engine, continuity, inbox_daemon, content_grounding). Now resolve portably via a new `ai/_paths.py` (env `DELIMIT_GATEWAY_REPO`/`DELIMIT_GATEWAY_ROOT` → `__file__`-relative repo root). Zero behavior change where the dev path was already correct.

Verified: resolves to /home/delimit/delimit-gateway on the dev box (no daemon regression); env override works; 307 tests pass; 0 functional literals remain; bundle byte-identical to the gateway change (paired branch). Additive/fix-only. Publish gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)