### PR TITLE
v4.7.9 — control plane: delimit control CLI + delimit_control MCP tool (LED-1709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 
+## [4.7.9] - 2026-06-09
+
+Control plane (LED-1709) — one interactive surface over the work that matters.
+
+### Added
+
+- **`delimit control`** — an interactive CLI that browses a single unified
+  queue across **attestations, approvals, sensing, and ops**, drills into any
+  item, and **approves/rejects** founder-approval items inline. Approving here
+  writes the *same* ack as replying "ship it" by email (no parallel store).
+- **`delimit_control` MCP tool** (`list`/`get`/`approve`/`reject`) — the shared
+  API behind both the CLI and the web dashboard (no split-brain): CLI calls it
+  directly, the dashboard via the existing MCP-over-HTTP route. Read-only
+  aggregation; the attestation lane is kept distinct from the sensing firehose.
+
 ## [4.7.8] - 2026-06-09
 
 ### Fixed

--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -7201,5 +7201,18 @@ program
         repl.start();
     });
 
+program
+    .command('control')
+    .description('Browse the unified control-plane queue (attestations, approvals, sensing, ops) and approve/reject founder-approval items')
+    .action(async () => {
+        const { run } = require('../lib/control-browser');
+        try {
+            await run();
+        } catch (e) {
+            console.error(require('chalk').red('  control plane error: ' + (e && e.message ? e.message : e)));
+            process.exitCode = 1;
+        }
+    });
+
 const normalizedArgs = normalizeNaturalLanguageArgs(process.argv);
 program.parse([process.argv[0], process.argv[1], ...normalizedArgs]);

--- a/gateway/ai/control_plane.py
+++ b/gateway/ai/control_plane.py
@@ -1,0 +1,597 @@
+"""Unified control-plane queue aggregator (LED-1709, Phase 0).
+
+READ-ONLY pure data layer. This module is the single shared backend that
+BOTH the CLI (direct MCP via ``delimit_control``) and the web dashboard
+(delimit-ui ``app/api/mcp`` route, MCP-over-HTTP) render. It therefore has
+NO CLI- or web-specific coupling: it only reads on-disk ``~/.delimit`` stores
+and returns plain dicts.
+
+It aggregates four existing storage sources into ONE normalized queue:
+
+  1. Attestations  -> class="attestation"  (the moat object; render first-class)
+  2. Approvals     -> class="approval"     (founder directives awaiting ack)
+  3. Ledger        -> class="sensing" (STR-*) | "ops" (LED-*/others)
+  4. Dispatches    -> class="ops"           (work-orders / agent actions)
+
+Every item is normalized to the SAME shape:
+
+    {
+        "id": str,
+        "class": "attestation" | "approval" | "sensing" | "ops",
+        "state": str,           # pending|in_progress|approved|rejected|done|open|...
+        "title": str,
+        "source": str,          # which store produced it
+        "created": str,         # ISO-8601
+        "summary": str,         # <= 200 chars
+        "links": dict,          # optional: replay_url, ledger_id, filepath, ...
+    }
+
+Design rules (Phase 0):
+  * Read-only. NEVER writes to any ~/.delimit store.
+  * Resilient/best-effort: a malformed or missing source must not crash the
+    whole queue. Each source is wrapped in try/except; bad records are
+    skipped, not fatal.
+  * Path resolution honors DELIMIT_HOME / DELIMIT_NAMESPACE_ROOT (LED-1188),
+    falling back to ~/.delimit. No hardcoded /home/delimit paths.
+  * stdlib only (plus optional reuse of ai.inbox_daemon's directive reader).
+
+The aggregator keeps the attestation lane retrievable distinctly so a client
+can show attestations separately from the (potentially ~1170) sensing items.
+See ``build_queue`` for the balancing behavior when class_filter is empty.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# ── Path resolution (LED-1188 / LED-1715 conventions) ────────────────────
+
+def _delimit_home() -> Path:
+    """Resolve the ~/.delimit home, honoring DELIMIT_HOME / DELIMIT_NAMESPACE_ROOT.
+
+    Read dynamically (not module-level) so tests can point DELIMIT_HOME at a
+    tmp dir per-test without import-order issues.
+    """
+    for env_key in ("DELIMIT_HOME", "DELIMIT_NAMESPACE_ROOT"):
+        val = os.environ.get(env_key)
+        if val:
+            return Path(val)
+    return Path.home() / ".delimit"
+
+
+_VALID_CLASSES = {"attestation", "approval", "sensing", "ops"}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _truncate(text: Any, limit: int = 200) -> str:
+    """Coerce to str and cap at `limit` chars (summary contract)."""
+    if text is None:
+        return ""
+    s = str(text).replace("\n", " ").strip()
+    if len(s) > limit:
+        return s[: limit - 1].rstrip() + "…"
+    return s
+
+
+def _iter_jsonl(path: Path):
+    """Yield parsed records from a JSONL file, skipping malformed lines.
+
+    Best-effort: a missing file yields nothing; a malformed line is skipped.
+    """
+    try:
+        if not path.exists():
+            return
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+    except OSError:
+        return
+
+
+def _sort_key(item: Dict[str, Any]) -> str:
+    """Sort key for newest-first ordering. Empty `created` sorts last."""
+    return item.get("created") or ""
+
+
+# ── Source 1: Attestations (the moat object) ─────────────────────────────
+
+def _load_attestations() -> List[Dict[str, Any]]:
+    """Normalize ~/.delimit/attestations/att_*.json into queue items.
+
+    Real schema (delimit.attestation.v1):
+        id, signature, signature_alg, bundle{schema, kind, wrapped_command,
+        repo_root, before_head, after_head, started_at, completed_at,
+        wrapped_exit, changed_files, governance{gates, violations, advisory}}
+
+    Mapping:
+        id      <- top-level "id"
+        state   <- derived from governance: rejected (violations & not advisory),
+                   done (clean), advisory (advisory-only gate)
+        title   <- bundle.kind or wrapped_command
+        created <- bundle.completed_at or started_at
+        summary <- wrapped_command + verdict
+        links   <- {replay_url?, repo, signature}
+    """
+    items: List[Dict[str, Any]] = []
+    att_dir = _delimit_home() / "attestations"
+    try:
+        if not att_dir.is_dir():
+            return items
+        files = sorted(att_dir.glob("att_*.json"))
+    except OSError:
+        return items
+
+    for fp in files:
+        try:
+            raw = json.loads(fp.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        try:
+            att_id = str(raw.get("id") or fp.stem)
+            bundle = raw.get("bundle") or {}
+            gov = bundle.get("governance") or {}
+            violations = gov.get("violations") or []
+            advisory = bool(gov.get("advisory"))
+
+            if violations and not advisory:
+                state = "rejected"
+            elif advisory:
+                state = "advisory"
+            else:
+                state = "done"
+
+            kind = bundle.get("kind") or bundle.get("schema") or "attestation"
+            wrapped = bundle.get("wrapped_command") or ""
+            created = (
+                bundle.get("completed_at")
+                or bundle.get("started_at")
+                or _file_mtime_iso(fp)
+            )
+
+            verdict = "clean" if not violations else f"{len(violations)} violation(s)"
+            summary = _truncate(
+                f"{wrapped or kind} — {verdict}"
+                + (f"; {', '.join(str(v) for v in violations)}" if violations else "")
+            )
+
+            links: Dict[str, Any] = {}
+            # Replay URL is not stored in the att_*.json today, but probe a few
+            # plausible field names so the lane is forward-compatible.
+            for key in ("replay_url", "replay", "url"):
+                if bundle.get(key):
+                    links["replay_url"] = bundle[key]
+                    break
+                if raw.get(key):
+                    links["replay_url"] = raw[key]
+                    break
+            if bundle.get("repo_root"):
+                links["repo"] = bundle["repo_root"]
+            if raw.get("signature"):
+                links["signature"] = raw["signature"]
+
+            items.append(
+                {
+                    "id": att_id,
+                    "class": "attestation",
+                    "state": state,
+                    "title": _truncate(str(kind), 200),
+                    "source": "attestations",
+                    "created": _to_iso(created),
+                    "summary": summary,
+                    "links": links,
+                    "_raw": raw,
+                }
+            )
+        except Exception:
+            # Per-record resilience: skip a bad record, keep the queue alive.
+            continue
+    return items
+
+
+# ── Source 2: Approvals (founder directives awaiting ack) ────────────────
+
+def _load_approvals() -> List[Dict[str, Any]]:
+    """Normalize founder directives awaiting completion into queue items.
+
+    Source: ~/.delimit/inbox_routing.jsonl, where the inbox daemon logs
+    `founder_directive_received` and `founder_directive_completed` events.
+    A directive is "pending approval" until a matching completed event by
+    subject exists.
+
+    We deliberately do NOT delegate to ai.inbox_daemon.get_pending_directives:
+    that reader binds ROUTING_LOG to Path.home()/".delimit" at import time and
+    ignores DELIMIT_HOME, which would make the control plane untestable and
+    break customer installs that relocate the home. _local_pending_directives()
+    applies the identical dedup-by-subject logic but resolves the path through
+    _delimit_home() each call.
+
+    Mapping:
+        id      <- "DIR-" + msg_id / fingerprint / subject-hash
+        state   <- "awaiting_approval"
+        title   <- subject
+        created <- timestamp
+        summary <- from / classification
+        links   <- {thread_url?, msg_id?}
+    """
+    items: List[Dict[str, Any]] = []
+    directives = _local_pending_directives()
+
+    for d in directives:
+        try:
+            subject = d.get("subject") or d.get("directive_subject") or ""
+            msg_id = d.get("msg_id") or d.get("fingerprint") or ""
+            ident = msg_id or _stable_hash(subject)
+            created = d.get("timestamp") or d.get("date") or ""
+            sender = d.get("from") or d.get("sender") or ""
+            classification = d.get("classification") or "owner-action"
+
+            links: Dict[str, Any] = {}
+            if d.get("thread_url"):
+                links["thread_url"] = d["thread_url"]
+            if msg_id:
+                links["msg_id"] = msg_id
+
+            items.append(
+                {
+                    "id": f"DIR-{ident}",
+                    "class": "approval",
+                    "state": "awaiting_approval",
+                    "title": _truncate(subject or "(no subject)", 200),
+                    "source": "inbox_routing",
+                    "created": _to_iso(created),
+                    "summary": _truncate(f"from {sender} [{classification}]"),
+                    "links": links,
+                    "_raw": d,
+                }
+            )
+        except Exception:
+            continue
+    return items
+
+
+def _local_pending_directives() -> List[Dict[str, Any]]:
+    """Fallback parse of pending founder directives from inbox_routing.jsonl.
+
+    Mirrors ai.inbox_daemon.get_pending_directives(): a directive is pending
+    unless a `founder_directive_completed` event shares its subject.
+    """
+    routing = _delimit_home() / "inbox_routing.jsonl"
+    received: List[Dict[str, Any]] = []
+    completed: set = set()
+    for entry in _iter_jsonl(routing):
+        try:
+            ev = entry.get("event")
+            if ev == "founder_directive_completed":
+                completed.add(entry.get("directive_subject", ""))
+            elif ev == "founder_directive_received":
+                received.append(entry)
+        except (AttributeError, KeyError):
+            continue
+    return [r for r in received if r.get("subject", "") not in completed]
+
+
+# ── Source 3: Ledger (open/pending items) ────────────────────────────────
+
+def _load_ledger() -> List[Dict[str, Any]]:
+    """Normalize open/pending ledger items into queue items.
+
+    Walks the central ~/.delimit/ledger/*.jsonl AND the partitioned
+    ~/.delimit/ledger-v2/<venture>/*.jsonl trees directly (read-only,
+    cross-venture). We do NOT route through ledger_manager.list_items
+    because that applies venture auto-detection + cursor pagination tuned
+    for a single-project call; the control plane wants every venture at once.
+
+    Record schema (observed): id, title, status, priority, description,
+    venture, tags, created_at, updated_at, hash, type.
+
+    Class split (per LED-1709 spec):
+        STR-* ids        -> class="sensing"
+        LED-*/all others -> class="ops"
+
+    Only open/pending-ish items are surfaced; done/closed/rejected are
+    excluded from the active queue (a closed ledger item is not "in the
+    queue"). De-duplicated by id (last write wins by created/updated time).
+    """
+    home = _delimit_home()
+    candidates: List[Path] = []
+    for base in (home / "ledger", home / "ledger-v2"):
+        try:
+            if base.is_dir():
+                candidates.extend(sorted(base.rglob("*.jsonl")))
+        except OSError:
+            continue
+
+    # Active states only. Anything not clearly terminal is treated as active.
+    terminal = {"done", "closed", "complete", "completed", "rejected", "cancelled",
+                "canceled", "resolved", "shipped", "merged"}
+
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for path in candidates:
+        # Skip non-item ledger files (links/updates are not queue items).
+        if path.name in {"links.jsonl", "updates.jsonl"}:
+            continue
+        for rec in _iter_jsonl(path):
+            try:
+                item_id = rec.get("id")
+                if not item_id:
+                    continue
+                item_id = str(item_id)
+                status = str(rec.get("status") or "open").lower()
+                if status in terminal:
+                    continue
+
+                cls = "sensing" if item_id.upper().startswith("STR-") else "ops"
+                created = rec.get("created_at") or rec.get("created") or ""
+                updated = rec.get("updated_at") or created
+
+                links: Dict[str, Any] = {"ledger_id": item_id}
+                if rec.get("venture"):
+                    links["venture"] = rec["venture"]
+
+                norm = {
+                    "id": item_id,
+                    "class": cls,
+                    "state": status,
+                    "title": _truncate(rec.get("title") or item_id, 200),
+                    "source": _ledger_source_label(path, home),
+                    "created": _to_iso(created),
+                    "summary": _truncate(rec.get("description") or rec.get("title") or ""),
+                    "links": links,
+                    "_raw": rec,
+                    "_updated": _to_iso(updated),
+                }
+                prev = by_id.get(item_id)
+                if prev is None or norm["_updated"] >= prev.get("_updated", ""):
+                    by_id[item_id] = norm
+            except Exception:
+                continue
+
+    out: List[Dict[str, Any]] = []
+    for it in by_id.values():
+        it.pop("_updated", None)
+        out.append(it)
+    return out
+
+
+def _ledger_source_label(path: Path, home: Path) -> str:
+    """Compact source label, e.g. 'ledger-v2/wire-report/strategy'."""
+    try:
+        rel = path.relative_to(home)
+        return str(rel.with_suffix(""))
+    except ValueError:
+        return path.stem
+
+
+# ── Source 4: Dispatches (work-orders / agent actions) ───────────────────
+
+def _load_dispatches() -> List[Dict[str, Any]]:
+    """Normalize work-orders and agent-action records into queue items.
+
+    Sources:
+        ~/.delimit/work-orders/*.json   (WO-*.json — primary)
+        ~/.delimit/agent_actions/*.json (agent dispatch audit records)
+
+    Work-order schema (observed): id, title, goal, status, priority,
+    created_at, ledger_item_id, filepath, estimated_minutes.
+
+    Mapping -> class="ops":
+        id      <- "id"
+        state   <- "status"
+        title   <- "title"
+        created <- "created_at"
+        summary <- "goal"
+        links   <- {filepath?, ledger_id?}
+    """
+    items: List[Dict[str, Any]] = []
+    home = _delimit_home()
+
+    # Active states only; completed work-orders aren't in the active queue.
+    terminal = {"done", "completed", "complete", "closed", "cancelled", "canceled"}
+
+    for sub, source in (("work-orders", "work-orders"), ("agent_actions", "agent_actions")):
+        d = home / sub
+        try:
+            if not d.is_dir():
+                continue
+            files = sorted(d.glob("*.json"))
+        except OSError:
+            continue
+        for fp in files:
+            try:
+                raw = json.loads(fp.read_text(encoding="utf-8", errors="replace"))
+            except (OSError, json.JSONDecodeError, ValueError):
+                continue
+            # agent_actions may store either a single record or a list.
+            records = raw if isinstance(raw, list) else [raw]
+            for rec in records:
+                if not isinstance(rec, dict):
+                    continue
+                try:
+                    item_id = str(rec.get("id") or rec.get("action_id") or fp.stem)
+                    status = str(rec.get("status") or "pending").lower()
+                    if status in terminal:
+                        continue
+                    created = rec.get("created_at") or rec.get("created") or rec.get("timestamp") or ""
+                    title = rec.get("title") or rec.get("goal") or rec.get("task") or item_id
+
+                    links: Dict[str, Any] = {}
+                    if rec.get("filepath"):
+                        links["filepath"] = rec["filepath"]
+                    if rec.get("ledger_item_id"):
+                        links["ledger_id"] = rec["ledger_item_id"]
+
+                    items.append(
+                        {
+                            "id": item_id,
+                            "class": "ops",
+                            "state": status,
+                            "title": _truncate(title, 200),
+                            "source": source,
+                            "created": _to_iso(created),
+                            "summary": _truncate(rec.get("goal") or rec.get("context") or title),
+                            "links": links,
+                            "_raw": rec,
+                        }
+                    )
+                except Exception:
+                    continue
+    return items
+
+
+# ── ISO / hashing utilities ──────────────────────────────────────────────
+
+def _to_iso(value: Any) -> str:
+    """Best-effort coercion to an ISO-8601 string; empty string on failure."""
+    if not value:
+        return ""
+    s = str(value)
+    return s
+
+
+def _file_mtime_iso(fp: Path) -> str:
+    try:
+        return datetime.fromtimestamp(fp.stat().st_mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        return ""
+
+
+def _stable_hash(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()[:12]
+
+
+# ── Public API ─────────────────────────────────────────────────────────--
+
+def _all_items() -> List[Dict[str, Any]]:
+    """Aggregate every source. Each loader is independently fault-isolated."""
+    out: List[Dict[str, Any]] = []
+    for loader in (_load_attestations, _load_approvals, _load_ledger, _load_dispatches):
+        try:
+            out.extend(loader() or [])
+        except Exception:
+            # A whole-source failure must not crash the queue.
+            continue
+    return out
+
+
+def build_queue(
+    class_filter: str = "",
+    state_filter: str = "",
+    limit: int = 100,
+) -> List[Dict[str, Any]]:
+    """Build the unified, normalized, newest-first queue.
+
+    Args:
+        class_filter: "" (all) | "attestation" | "approval" | "sensing" | "ops".
+        state_filter: "" (all) | a state string (e.g. "open", "pending",
+            "awaiting_approval", "done"). Case-insensitive.
+        limit: max items returned (default 100).
+
+    Returns:
+        A list of normalized item dicts (the `_raw` key is stripped here —
+        get_item() exposes raw payloads). Sorted newest-first by `created`.
+
+    Lane balancing (documented contract): when class_filter is empty, sensing
+    items can vastly outnumber every other lane (~1170 STR-* items). To keep
+    the moat (attestation) and approval lanes from being drowned, the unfiltered
+    result reserves capacity per lane: attestations and approvals are never
+    truncated by the sensing flood — they are taken in full (newest-first) up to
+    `limit`, and the remaining budget is filled with ops then sensing items
+    (each newest-first). A client wanting ONLY sensing should pass
+    class_filter="sensing" to get the full sensing lane up to `limit`.
+    """
+    items = _all_items()
+
+    cf = (class_filter or "").strip().lower()
+    sf = (state_filter or "").strip().lower()
+
+    if cf and cf in _VALID_CLASSES:
+        items = [it for it in items if it.get("class") == cf]
+    if sf:
+        items = [it for it in items if str(it.get("state", "")).lower() == sf]
+
+    # Strip internal keys from the list projection.
+    def _public(it: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: v for k, v in it.items() if not k.startswith("_")}
+
+    try:
+        cap = int(limit)
+    except (TypeError, ValueError):
+        cap = 100
+    if cap < 0:
+        cap = 0
+
+    # When a class filter is active (or no balancing needed), simple newest-first.
+    if cf:
+        items.sort(key=_sort_key, reverse=True)
+        return [_public(it) for it in items[:cap]]
+
+    # Unfiltered: balance lanes so sensing can't drown attestation/approval.
+    lanes: Dict[str, List[Dict[str, Any]]] = {c: [] for c in _VALID_CLASSES}
+    for it in items:
+        c = it.get("class")
+        if c in lanes:
+            lanes[c].append(it)
+    for c in lanes:
+        lanes[c].sort(key=_sort_key, reverse=True)
+
+    result: List[Dict[str, Any]] = []
+    # Priority order: attestation (moat) + approval first, then ops, then sensing.
+    for lane in ("attestation", "approval", "ops", "sensing"):
+        for it in lanes[lane]:
+            if len(result) >= cap:
+                break
+            result.append(it)
+        if len(result) >= cap:
+            break
+
+    # Final newest-first sort across the balanced selection.
+    result.sort(key=_sort_key, reverse=True)
+    return [_public(it) for it in result[:cap]]
+
+
+def get_item(item_id: str) -> Optional[Dict[str, Any]]:
+    """Return one normalized item by id, including its raw payload under `raw`.
+
+    Args:
+        item_id: the normalized item id (e.g. "att_023f00875109bc67",
+            "STR-437", "LED-1709", "WO-2026-04-18-001", "DIR-679").
+
+    Returns:
+        The normalized dict (all public keys) plus a `raw` key holding the
+        original source payload, or None if no item matches.
+    """
+    if not item_id:
+        return None
+    target = str(item_id)
+    for it in _all_items():
+        if str(it.get("id")) == target:
+            out = {k: v for k, v in it.items() if not k.startswith("_")}
+            out["raw"] = it.get("_raw")
+            return out
+    return None
+
+
+def counts(items: List[Dict[str, Any]]) -> Dict[str, Dict[str, int]]:
+    """Compute counts_by_class and counts_by_state for a list of items."""
+    by_class: Dict[str, int] = {}
+    by_state: Dict[str, int] = {}
+    for it in items:
+        c = str(it.get("class", "unknown"))
+        s = str(it.get("state", "unknown"))
+        by_class[c] = by_class.get(c, 0) + 1
+        by_state[s] = by_state.get(s, 0) + 1
+    return {"counts_by_class": by_class, "counts_by_state": by_state}

--- a/gateway/ai/control_plane.py
+++ b/gateway/ai/control_plane.py
@@ -1,10 +1,16 @@
-"""Unified control-plane queue aggregator (LED-1709, Phase 0).
+"""Unified control-plane queue aggregator (LED-1709, Phase 0 + Phase 1).
 
-READ-ONLY pure data layer. This module is the single shared backend that
-BOTH the CLI (direct MCP via ``delimit_control``) and the web dashboard
-(delimit-ui ``app/api/mcp`` route, MCP-over-HTTP) render. It therefore has
-NO CLI- or web-specific coupling: it only reads on-disk ``~/.delimit`` stores
-and returns plain dicts.
+The aggregation layer (build_queue / get_item / counts) is READ-ONLY. This
+module is the single shared backend that BOTH the CLI (direct MCP via
+``delimit_control``) and the web dashboard (delimit-ui ``app/api/mcp`` route,
+MCP-over-HTTP) render. It therefore has NO CLI- or web-specific coupling: it
+only reads on-disk ``~/.delimit`` stores and returns plain dicts.
+
+Phase 1 adds two WRITE verbs — ``approve`` and ``reject`` — that act ONLY on
+class="approval" items and route through the SAME founder-approval ack store
+the email "ship it" loop uses (``inbox_routing.jsonl``,
+``founder_directive_completed`` events). They write no new/parallel store.
+See the "Write verbs" section near the bottom of this file.
 
 It aggregates four existing storage sources into ONE normalized queue:
 
@@ -583,6 +589,167 @@ def get_item(item_id: str) -> Optional[Dict[str, Any]]:
             out["raw"] = it.get("_raw")
             return out
     return None
+
+
+# ── Write verbs (LED-1709 Phase 1) ──────────────────────────────────────-
+#
+# approve/reject ONLY act on class="approval" items, and they route through
+# the SAME founder-approval ack store the email loop uses: they append a
+# `founder_directive_completed` event to ~/.delimit/inbox_routing.jsonl keyed
+# by `directive_subject`. That is byte-equivalent to what
+# ai.inbox_daemon.complete_directive() writes when the founder replies
+# "ship it" by email (inbox_daemon.complete_directive ->
+# _log_routing({"event": "founder_directive_completed",
+#               "directive_subject": subject, "result": result})).
+#
+# We do NOT call inbox_daemon.complete_directive() directly for two reasons:
+#   1. It binds ROUTING_LOG to Path.home()/".delimit" at import time and
+#      ignores DELIMIT_HOME — the same reason _load_approvals does not reuse
+#      get_pending_directives. Routing through it would make the write
+#      untestable and break relocated-home customer installs.
+#   2. It additionally SENDS a confirmation email (the receive-flow's
+#      concern). The CLI/web act-of-approval is the founder acting directly,
+#      not an inbound email being acked, so it must not emit an outbound
+#      email. The DURABLE state — the dedup-by-subject completed event that
+#      removes the directive from the pending queue for BOTH the email loop
+#      and this control plane — is identical.
+#
+# There is NO separate rejected event in the daemon's schema today (the only
+# directive lifecycle is received -> completed, deduped by subject). Per the
+# Phase 1 spec, reject therefore records the same completed event with an
+# explicit `disposition: "rejected"` field (plus the note as `result`),
+# keeping it consistent with the daemon's schema and dedup key.
+
+def _append_routing_event(entry: Dict[str, Any]) -> None:
+    """Append one event to ~/.delimit/inbox_routing.jsonl (DELIMIT_HOME-aware).
+
+    Mirrors ai.inbox_daemon._log_routing's on-disk format (adds `daemon` and
+    `timestamp`) but resolves the path through _delimit_home() so it honors
+    DELIMIT_HOME / DELIMIT_NAMESPACE_ROOT and is testable. This is the ONLY
+    place the control plane writes; there is no parallel approval store.
+    """
+    routing = _delimit_home() / "inbox_routing.jsonl"
+    routing.parent.mkdir(parents=True, exist_ok=True)
+    payload = dict(entry)
+    payload.setdefault("daemon", True)
+    payload["timestamp"] = datetime.now(timezone.utc).isoformat()
+    with open(routing, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload) + "\n")
+
+
+def _approval_subject_for(item_id: str) -> Optional[str]:
+    """Resolve the underlying directive subject for an approval-class item id.
+
+    Returns the subject string for a still-pending approval item, or None if
+    the id is not an approval-class item (wrong class / not found / already
+    completed and therefore no longer pending).
+    """
+    it = get_item(item_id)
+    if it is None or it.get("class") != "approval":
+        return None
+    raw = it.get("raw") or {}
+    return raw.get("subject") or raw.get("directive_subject") or ""
+
+
+def _is_subject_completed(subject: str) -> bool:
+    """True if a founder_directive_completed event already exists for subject."""
+    routing = _delimit_home() / "inbox_routing.jsonl"
+    for entry in _iter_jsonl(routing):
+        try:
+            if (entry.get("event") == "founder_directive_completed"
+                    and entry.get("directive_subject", "") == subject):
+                return True
+        except AttributeError:
+            continue
+    return False
+
+
+def _ack_directive(item_id: str, action: str, note: str = "") -> Dict[str, Any]:
+    """Shared approve/reject implementation.
+
+    action is "approve" or "reject". Both write the SAME
+    `founder_directive_completed` event (dedup-by-subject) that the email
+    "ship it" loop writes; reject additionally stamps disposition="rejected".
+
+    Idempotent: if the directive is already completed, no-op with a clear
+    status. Non-approval classes return {"status": "unsupported", ...}.
+    """
+    if not item_id:
+        return {"status": "error", "item_id": item_id, "action": action,
+                "reason": "item_id is required"}
+
+    it = get_item(item_id)
+    if it is None:
+        return {"status": "not_found", "item_id": item_id, "action": action,
+                "reason": "no such item in the control-plane queue"}
+
+    if it.get("class") != "approval":
+        return {
+            "status": "unsupported",
+            "item_id": item_id,
+            "action": action,
+            "class": it.get("class"),
+            "reason": "approve/reject only applies to approval-class items in Phase 1",
+        }
+
+    raw = it.get("raw") or {}
+    subject = raw.get("subject") or raw.get("directive_subject") or ""
+    if not subject:
+        return {"status": "error", "item_id": item_id, "action": action,
+                "reason": "approval item has no resolvable directive subject"}
+
+    # Idempotency: a completed event for this subject already routes it out of
+    # the pending queue for both the email loop and this control plane.
+    if _is_subject_completed(subject):
+        return {"status": "noop", "item_id": item_id, "action": action,
+                "subject": subject, "reason": "directive already acked/completed"}
+
+    result = note or ("approved via control plane" if action == "approve"
+                      else "rejected via control plane")
+    event: Dict[str, Any] = {
+        "event": "founder_directive_completed",
+        "directive_subject": subject,
+        "result": result,
+        "source": "control_plane",
+    }
+    if action == "reject":
+        event["disposition"] = "rejected"
+
+    try:
+        _append_routing_event(event)
+    except OSError as exc:
+        return {"status": "error", "item_id": item_id, "action": action,
+                "reason": f"failed to write routing ack: {exc}"}
+
+    return {
+        "status": "approved" if action == "approve" else "rejected",
+        "item_id": item_id,
+        "action": action,
+        "subject": subject,
+        "result": result,
+    }
+
+
+def approve(item_id: str, note: str = "") -> Dict[str, Any]:
+    """Approve an approval-class item (mirror the email "ship it" ack).
+
+    Routes through the existing founder-approval store: appends a
+    `founder_directive_completed` event keyed by the directive subject — the
+    same durable transition the inbox daemon writes on an email approval. Only
+    acts on class="approval" items; idempotent re-approve no-ops.
+    """
+    return _ack_directive(item_id, "approve", note)
+
+
+def reject(item_id: str, note: str = "") -> Dict[str, Any]:
+    """Reject an approval-class item (mirror the email rejection ack).
+
+    Records a `founder_directive_completed` event with disposition="rejected"
+    (the daemon has no distinct rejected event; completed-with-disposition is
+    consistent with its dedup-by-subject schema). Only acts on
+    class="approval" items; idempotent re-reject no-ops.
+    """
+    return _ack_directive(item_id, "reject", note)
 
 
 def counts(items: List[Dict[str, Any]]) -> Dict[str, Dict[str, int]]:

--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -13047,6 +13047,60 @@ def delimit_agent_dashboard() -> Dict[str, Any]:
 
 
 @mcp.tool()
+def delimit_control(
+    action: Annotated[str, Field(description="\"list\" (default) or \"get\". Phase 0 is READ-ONLY; approve/dispatch/etc. are coming in Phase 1.")] = "list",
+    class_filter: Annotated[str, Field(description="Lane filter: \"\" (all), \"attestation\", \"approval\", \"sensing\", or \"ops\".")] = "",
+    state_filter: Annotated[str, Field(description="State filter, e.g. \"open\", \"pending\", \"awaiting_approval\", \"done\". \"\" = all.")] = "",
+    item_id: Annotated[str, Field(description="For action=\"get\": the normalized item id (e.g. \"att_…\", \"STR-437\", \"LED-1709\", \"WO-…\", \"DIR-…\").")] = "",
+    limit: Annotated[int, Field(description="Max items for action=\"list\" (default 100).")] = 100,
+) -> Dict[str, Any]:
+    """Aggregate all governance lanes into one read-only queue (LED-1709).
+
+    When to use: as the shared queue the CLI and web dashboard both render —
+    attestations, approvals, sensing (STR-*), ops (LED-*/work-orders) in one list.
+    When NOT to use: to ACT on an item; Phase 0 is read-only (approve/dispatch
+    land in Phase 1) — mutate via the owning tool instead.
+
+    Sibling contrast: delimit_agent_dashboard is dispatch-only,
+    delimit_ledger_context is one-venture-only, delimit_notify_inbox is
+    inbox-only; this unifies all four into one lane-aware read view.
+
+    Side effects: READ-ONLY. Reads ~/.delimit stores; never writes.
+
+    Args:
+        action: "list" (default, queue + counts) or "get" (one item + raw).
+        class_filter: lane ("", attestation, approval, sensing, ops).
+        state_filter: state (e.g. open, pending, awaiting_approval); "" = all.
+        item_id: required for "get".
+        limit: max list items (default 100); empty class_filter balances lanes.
+
+    Returns:
+        list: {queue, counts_by_class, counts_by_state}.
+        get:  {item: {...normalized..., raw}} or {item: None}.
+    """
+    from ai import control_plane
+
+    act = (action or "list").strip().lower()
+    if act == "get":
+        item = _safe_call(control_plane.get_item, item_id=item_id)
+        # _safe_call wraps non-dict returns; normalize to {item: ...}.
+        if isinstance(item, dict) and item.get("error"):
+            return _with_next_steps("control", item)
+        return _with_next_steps("control", {"item": item})
+
+    queue = control_plane.build_queue(
+        class_filter=class_filter, state_filter=state_filter, limit=limit
+    )
+    counts = control_plane.counts(queue)
+    result = {
+        "queue": queue,
+        "counts_by_class": counts["counts_by_class"],
+        "counts_by_state": counts["counts_by_state"],
+    }
+    return _with_next_steps("control", result)
+
+
+@mcp.tool()
 def delimit_agent_policy(model: Annotated[str, Field(description="AI model name — \"claude\", \"codex\", \"gemini\", \"cursor\". Empty = list all.")] = "", ledger: Annotated[str, Field(description="Ledger access level.")] = "", memory: Annotated[str, Field(description="Memory access level.")] = "",
                           deploy: Annotated[str, Field(description="Allow deploys (\"true\"/\"false\").")] = "", evidence: Annotated[str, Field(description="Evidence access level.")] = "",
                           secrets: Annotated[str, Field(description="Allow secret access (\"true\"/\"false\").")] = "", custom_constraints: Annotated[str, Field(description="Comma-separated constraints, e.g. \"no-deploy,no-publish\".")] = "") -> Dict[str, Any]:

--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -13048,35 +13048,42 @@ def delimit_agent_dashboard() -> Dict[str, Any]:
 
 @mcp.tool()
 def delimit_control(
-    action: Annotated[str, Field(description="\"list\" (default) or \"get\". Phase 0 is READ-ONLY; approve/dispatch/etc. are coming in Phase 1.")] = "list",
+    action: Annotated[str, Field(description="\"list\" (default), \"get\", \"approve\", or \"reject\". list/get are read-only; approve/reject act ONLY on approval-class items and mirror the email \"ship it\" ack loop.")] = "list",
     class_filter: Annotated[str, Field(description="Lane filter: \"\" (all), \"attestation\", \"approval\", \"sensing\", or \"ops\".")] = "",
     state_filter: Annotated[str, Field(description="State filter, e.g. \"open\", \"pending\", \"awaiting_approval\", \"done\". \"\" = all.")] = "",
-    item_id: Annotated[str, Field(description="For action=\"get\": the normalized item id (e.g. \"att_…\", \"STR-437\", \"LED-1709\", \"WO-…\", \"DIR-…\").")] = "",
+    item_id: Annotated[str, Field(description="Required for \"get\", \"approve\", \"reject\": the normalized item id (e.g. \"att_…\", \"STR-437\", \"LED-1709\", \"WO-…\", \"DIR-…\").")] = "",
     limit: Annotated[int, Field(description="Max items for action=\"list\" (default 100).")] = 100,
+    note: Annotated[str, Field(description="Optional note recorded as the ack result for action=\"approve\"/\"reject\".")] = "",
 ) -> Dict[str, Any]:
-    """Aggregate all governance lanes into one read-only queue (LED-1709).
+    """Aggregate all governance lanes into one queue; approve/reject approvals (LED-1709).
 
     When to use: as the shared queue the CLI and web dashboard both render —
-    attestations, approvals, sensing (STR-*), ops (LED-*/work-orders) in one list.
-    When NOT to use: to ACT on an item; Phase 0 is read-only (approve/dispatch
-    land in Phase 1) — mutate via the owning tool instead.
+    attestations, approvals, sensing (STR-*), ops (LED-*) — and to
+    approve/reject founder-approval items from that same surface.
+    When NOT to use: to act on attestation/sensing/ops items; approve/reject
+    are approval-class only in Phase 1 (mutate those via their owning tool).
 
     Sibling contrast: delimit_agent_dashboard is dispatch-only,
     delimit_ledger_context is one-venture-only, delimit_notify_inbox is
-    inbox-only; this unifies all four into one lane-aware read view.
+    inbox-only; this unifies all four into one lane-aware view.
 
-    Side effects: READ-ONLY. Reads ~/.delimit stores; never writes.
+    Side effects: list/get are READ-ONLY. approve/reject append the same
+    `founder_directive_completed` ack the email "ship it" loop writes to the
+    EXISTING store (~/.delimit/inbox_routing.jsonl); reject stamps
+    disposition="rejected". No new store; idempotent re-approve no-ops.
 
     Args:
-        action: "list" (default, queue + counts) or "get" (one item + raw).
-        class_filter: lane ("", attestation, approval, sensing, ops).
-        state_filter: state (e.g. open, pending, awaiting_approval); "" = all.
-        item_id: required for "get".
+        action: "list" (default), "get", "approve", or "reject" (approve/reject
+            are approval-class only).
+        class_filter: lane, e.g. "" (all), attestation, approval, sensing, ops.
+        state_filter: state (e.g. open, awaiting_approval); "" = all.
+        item_id: required for get/approve/reject.
         limit: max list items (default 100); empty class_filter balances lanes.
+        note: optional ack result note for approve/reject.
 
     Returns:
-        list: {queue, counts_by_class, counts_by_state}.
-        get:  {item: {...normalized..., raw}} or {item: None}.
+        list: {queue, counts_by_class, counts_by_state}; get: {item} or
+        {item: None}; approve/reject: {status, item_id, action, subject?}.
     """
     from ai import control_plane
 
@@ -13087,6 +13094,11 @@ def delimit_control(
         if isinstance(item, dict) and item.get("error"):
             return _with_next_steps("control", item)
         return _with_next_steps("control", {"item": item})
+
+    if act in ("approve", "reject"):
+        verb = control_plane.approve if act == "approve" else control_plane.reject
+        res = _safe_call(verb, item_id=item_id, note=note)
+        return _with_next_steps("control", res)
 
     queue = control_plane.build_queue(
         class_filter=class_filter, state_filter=state_filter, limit=limit

--- a/lib/control-browser.js
+++ b/lib/control-browser.js
@@ -1,0 +1,297 @@
+// `delimit control` — interactive browser over the LED-1709 unified control
+// plane. Dependency-light: uses the package's existing `inquirer` + `chalk`
+// (same as the chat REPL); NO blessed/ink.
+//
+// It consumes the SHARED backend (ai.control_plane) via a python3 shim,
+// resolving the server path exactly the way chat-repl's
+// captureSoulForMigration does (bundled gateway first, then the installed
+// ~/.delimit/server). It does NOT reimplement aggregation — the same
+// build_queue/get_item/approve/reject the web dashboard hits via
+// /api/mcp -> delimit_control. One shared backend, two surfaces.
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const chalk = require('chalk');
+const inquirer = require('inquirer');
+
+const PKG_VERSION = (() => {
+    try { return require('../package.json').version; } catch (e) { return ''; }
+})();
+
+const CLASSES = ['attestation', 'approval', 'sensing', 'ops'];
+
+// Resolve the gateway base that holds ai/control_plane.py. Bundled gateway
+// first (shipped with the npm package), then the installed MCP server.
+function resolveBase() {
+    const candidates = [
+        path.join(__dirname, '..', 'gateway'),
+        path.join(os.homedir(), '.delimit', 'server'),
+    ];
+    for (const base of candidates) {
+        if (fs.existsSync(path.join(base, 'ai', 'control_plane.py'))) return base;
+    }
+    return null;
+}
+
+// Run a one-liner against ai.control_plane and parse its JSON stdout.
+// `expr` is a python expression returning a JSON-serializable value.
+function callBackend(base, expr) {
+    const py = `import sys, json; sys.path.insert(0, ${JSON.stringify(base)}); `
+        + `from ai import control_plane as cp; `
+        + `print(json.dumps(${expr}))`;
+    const r = spawnSync('python3', ['-c', py], { encoding: 'utf-8' });
+    if (r.status !== 0) {
+        const err = (r.stderr || r.error || 'unknown error').toString().trim();
+        throw new Error(err.split('\n').pop() || 'backend call failed');
+    }
+    try {
+        return JSON.parse((r.stdout || '').trim());
+    } catch (e) {
+        throw new Error('could not parse backend output: ' + e.message);
+    }
+}
+
+function buildQueue(base, classFilter, limit) {
+    const cf = JSON.stringify(classFilter || '');
+    const lim = parseInt(limit, 10) || 100;
+    return callBackend(base, `cp.build_queue(class_filter=${cf}, state_filter="", limit=${lim})`);
+}
+
+function getItem(base, itemId) {
+    return callBackend(base, `cp.get_item(${JSON.stringify(itemId)})`);
+}
+
+function act(base, verb, itemId, note) {
+    // verb is "approve" or "reject"
+    const fn = verb === 'approve' ? 'approve' : 'reject';
+    return callBackend(base, `cp.${fn}(${JSON.stringify(itemId)}, note=${JSON.stringify(note || '')})`);
+}
+
+function banner() {
+    console.log(chalk.magenta.bold('\n  ┌──────────────────────────────────────────┐'));
+    console.log(chalk.magenta.bold('  │  ') + chalk.magenta('Delimit Control Plane') + chalk.gray('  ·  v' + PKG_VERSION)
+        + chalk.magenta.bold('          │'));
+    console.log(chalk.magenta.bold('  └──────────────────────────────────────────┘'));
+    console.log(chalk.gray('  The merge gate for AI-written code · unified queue\n'));
+}
+
+function classColor(cls) {
+    switch (cls) {
+        case 'attestation': return chalk.cyan(cls);
+        case 'approval': return chalk.yellow(cls);
+        case 'sensing': return chalk.blue(cls);
+        case 'ops': return chalk.green(cls);
+        default: return chalk.gray(cls || 'unknown');
+    }
+}
+
+function renderCounts(queue) {
+    const byClass = {};
+    for (const it of queue) {
+        const c = it.class || 'unknown';
+        byClass[c] = (byClass[c] || 0) + 1;
+    }
+    const parts = CLASSES.map(c => `${classColor(c)} ${chalk.bold(byClass[c] || 0)}`);
+    console.log('  Lanes: ' + parts.join(chalk.gray('  ·  ')) + chalk.gray(`   (total ${queue.length})`));
+}
+
+async function pickLane() {
+    const { lane } = await inquirer.prompt([{
+        type: 'list',
+        name: 'lane',
+        message: 'Pick a lane to browse:',
+        choices: [
+            { name: 'all (balanced)', value: '' },
+            { name: 'attestation (signed evidence)', value: 'attestation' },
+            { name: 'approval (founder directives awaiting ack)', value: 'approval' },
+            { name: 'sensing (STR-*)', value: 'sensing' },
+            { name: 'ops (LED-* / work-orders)', value: 'ops' },
+            new inquirer.Separator(),
+            { name: 'quit', value: '__quit__' },
+        ],
+        loop: false,
+    }]);
+    return lane;
+}
+
+function itemLabel(it) {
+    const id = chalk.bold((it.id || '?').padEnd(22).slice(0, 22));
+    const state = chalk.gray((it.state || '').padEnd(18).slice(0, 18));
+    const title = it.title || '(untitled)';
+    return `${id} ${state} ${title}`;
+}
+
+async function pickItem(queue) {
+    if (!queue.length) {
+        console.log(chalk.gray('\n  (no items in this lane)\n'));
+        return '__back__';
+    }
+    const choices = queue.map(it => ({ name: itemLabel(it), value: it.id }));
+    choices.push(new inquirer.Separator());
+    choices.push({ name: 'back', value: '__back__' });
+    const { id } = await inquirer.prompt([{
+        type: 'list',
+        name: 'id',
+        message: 'Select an item:',
+        choices,
+        pageSize: 15,
+        loop: false,
+    }]);
+    return id;
+}
+
+function renderDetail(item) {
+    console.log(chalk.magenta('\n  ─── item detail ───────────────────────────'));
+    console.log('  id:      ' + chalk.bold(item.id));
+    console.log('  class:   ' + classColor(item.class));
+    console.log('  state:   ' + chalk.bold(item.state || ''));
+    console.log('  title:   ' + (item.title || ''));
+    console.log('  source:  ' + chalk.gray(item.source || ''));
+    console.log('  created: ' + chalk.gray(item.created || ''));
+    if (item.summary) console.log('  summary: ' + item.summary);
+    if (item.links && Object.keys(item.links).length) {
+        console.log('  links:   ' + chalk.gray(JSON.stringify(item.links)));
+    }
+    if (item.raw !== undefined) {
+        const rawStr = JSON.stringify(item.raw, null, 2)
+            .split('\n').map(l => '    ' + l).join('\n');
+        console.log(chalk.gray('  raw:'));
+        console.log(chalk.gray(rawStr));
+    }
+    console.log(chalk.magenta('  ───────────────────────────────────────────\n'));
+}
+
+// Returns true if the caller should refresh the lane (state changed).
+async function handleItem(base, itemId) {
+    let item;
+    try {
+        item = getItem(base, itemId);
+    } catch (e) {
+        console.log(chalk.red('\n  Could not load item: ' + e.message + '\n'));
+        return false;
+    }
+    if (!item) {
+        console.log(chalk.gray('\n  (item no longer in the queue)\n'));
+        return true;
+    }
+    renderDetail(item);
+
+    // Read-only browsing always works. Only approval-class items offer
+    // approve/reject; everything else is back-only.
+    if (item.class !== 'approval') {
+        await inquirer.prompt([{
+            type: 'list', name: 'next', message: 'Action:',
+            choices: [{ name: 'back', value: '__back__' }], loop: false,
+        }]);
+        return false;
+    }
+
+    const { choice } = await inquirer.prompt([{
+        type: 'list',
+        name: 'choice',
+        message: 'This is a founder-approval item — approve mirrors the email "ship it" ack:',
+        choices: [
+            { name: chalk.green('Approve'), value: 'approve' },
+            { name: chalk.red('Reject'), value: 'reject' },
+            new inquirer.Separator(),
+            { name: 'Back (read-only, no change)', value: '__back__' },
+        ],
+        loop: false,
+    }]);
+
+    if (choice === '__back__') return false;
+
+    const { note } = await inquirer.prompt([{
+        type: 'input',
+        name: 'note',
+        message: `Optional note for this ${choice} (enter to skip):`,
+    }]);
+
+    try {
+        const res = act(base, choice, itemId, note);
+        const status = res && res.status;
+        if (status === 'approved') {
+            console.log(chalk.green(`\n  ✓ Approved ${itemId} — directive-completed ack written to the inbox approval store.\n`));
+        } else if (status === 'rejected') {
+            console.log(chalk.yellow(`\n  ✓ Rejected ${itemId} — directive-completed ack (disposition=rejected) written.\n`));
+        } else if (status === 'noop') {
+            console.log(chalk.gray(`\n  • ${itemId} was already acked — no change.\n`));
+        } else {
+            console.log(chalk.gray('\n  ' + JSON.stringify(res) + '\n'));
+        }
+    } catch (e) {
+        console.log(chalk.red('\n  Action failed: ' + e.message + '\n'));
+        return false;
+    }
+    return true;
+}
+
+async function run() {
+    banner();
+
+    const base = resolveBase();
+    if (!base) {
+        console.log(chalk.red('  Could not locate the Delimit control-plane backend'
+            + ' (ai/control_plane.py) in the bundled gateway or ~/.delimit/server.'));
+        console.log(chalk.gray('  Run `delimit install` to set up the MCP server.\n'));
+        process.exitCode = 1;
+        return;
+    }
+
+    // Clean exit on Ctrl-C.
+    process.on('SIGINT', () => {
+        console.log(chalk.gray('\n  Bye.\n'));
+        process.exit(0);
+    });
+
+    // Outer loop: pick a lane until quit.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        let lane;
+        try {
+            lane = await pickLane();
+        } catch (e) {
+            // inquirer throws on Ctrl-C/closed TTY — exit cleanly.
+            console.log(chalk.gray('\n  Bye.\n'));
+            return;
+        }
+        if (lane === '__quit__') {
+            console.log(chalk.gray('\n  Bye.\n'));
+            return;
+        }
+
+        // Inner loop: browse items in the lane until back.
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            let queue;
+            try {
+                queue = buildQueue(base, lane, 100);
+            } catch (e) {
+                console.log(chalk.red('\n  Failed to load queue: ' + e.message + '\n'));
+                break;
+            }
+            renderCounts(queue);
+            let itemId;
+            try {
+                itemId = await pickItem(queue);
+            } catch (e) {
+                console.log(chalk.gray('\n  Bye.\n'));
+                return;
+            }
+            if (itemId === '__back__') break;
+            await handleItem(base, itemId);
+            // loop back to the (refreshed) item list
+        }
+    }
+}
+
+module.exports = {
+    run,
+    // exported for testing / reuse
+    resolveBase,
+    buildQueue,
+    getItem,
+    act,
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.7.8",
+  "version": "4.7.9",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "postinstall": "node scripts/postinstall.js",
     "sync-gateway": "bash scripts/sync-gateway.sh",
     "prepublishOnly": "bash scripts/publish-ci-guard.sh && npm run sync-gateway && bash scripts/build-license-core.sh && bash scripts/security-check.sh",
-    "test": "node --test tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js tests/auth-signin.test.js tests/auth-signout.test.js tests/migration-2092-banner.test.js"
+    "test": "node --test tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js tests/auth-signin.test.js tests/auth-signout.test.js tests/migration-2092-banner.test.js tests/control-browser.test.js"
   },
   "keywords": [
     "openapi",

--- a/tests/control-browser.test.js
+++ b/tests/control-browser.test.js
@@ -1,0 +1,118 @@
+/**
+ * LED-1709 Phase 1: tests for the `delimit control` CLI backend wiring.
+ *
+ * The interactive prompts (inquirer) are not driven here; instead we lock the
+ * contract that the CLI consumes the SHARED control_plane backend via the
+ * python3 shim (resolveBase + buildQueue/getItem/act) and that approve routes
+ * through the existing inbox ack store — never a parallel approval store.
+ *
+ * Skips automatically if python3 isn't available on PATH.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const cb = require('../lib/control-browser');
+
+const HAVE_PY = spawnSync('python3', ['--version']).status === 0;
+const BASE = cb.resolveBase();
+// The shared backend must be reachable for the round-trip tests.
+const HAVE_BACKEND = !!BASE && fs.existsSync(path.join(BASE, 'ai', 'control_plane.py'));
+
+const ORIG_HOME = process.env.DELIMIT_HOME;
+const ORIG_NS = process.env.DELIMIT_NAMESPACE_ROOT;
+let tmp;
+
+function seedHome(dir) {
+    fs.mkdirSync(path.join(dir, 'attestations'), { recursive: true });
+    fs.writeFileSync(
+        path.join(dir, 'attestations', 'att_x.json'),
+        JSON.stringify({
+            id: 'att_x',
+            bundle: {
+                kind: 'merge_attestation', wrapped_command: 'pytest',
+                completed_at: '2026-06-09T00:00:00Z',
+                governance: { violations: [], advisory: false },
+            },
+        })
+    );
+    // one pending founder directive (approval-class)
+    fs.writeFileSync(
+        path.join(dir, 'inbox_routing.jsonl'),
+        JSON.stringify({
+            event: 'founder_directive_received', subject: 'Ship it',
+            msg_id: '7', from: 'founder@x.com', timestamp: '2026-06-09T10:00:00+00:00',
+        }) + '\n'
+    );
+}
+
+describe('lib/control-browser: shared backend wiring', () => {
+    before(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ctl-test-'));
+        seedHome(tmp);
+        process.env.DELIMIT_HOME = tmp;
+        delete process.env.DELIMIT_NAMESPACE_ROOT;
+    });
+
+    after(() => {
+        if (ORIG_HOME === undefined) delete process.env.DELIMIT_HOME;
+        else process.env.DELIMIT_HOME = ORIG_HOME;
+        if (ORIG_NS === undefined) delete process.env.DELIMIT_NAMESPACE_ROOT;
+        else process.env.DELIMIT_NAMESPACE_ROOT = ORIG_NS;
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (e) {}
+    });
+
+    it('resolveBase finds the bundled gateway control_plane', () => {
+        assert.ok(HAVE_BACKEND, 'expected ai/control_plane.py in the bundled gateway');
+    });
+
+    it('buildQueue returns normalized items from the shared backend', (t) => {
+        if (!HAVE_PY || !HAVE_BACKEND) return t.skip('python3/backend unavailable');
+        const q = cb.buildQueue(BASE, '', 100);
+        assert.ok(Array.isArray(q));
+        const classes = new Set(q.map(it => it.class));
+        assert.ok(classes.has('attestation'));
+        assert.ok(classes.has('approval'));
+    });
+
+    it('getItem returns the raw payload for an attestation', (t) => {
+        if (!HAVE_PY || !HAVE_BACKEND) return t.skip('python3/backend unavailable');
+        const item = cb.getItem(BASE, 'att_x');
+        assert.ok(item);
+        assert.strictEqual(item.class, 'attestation');
+        assert.ok('raw' in item);
+    });
+
+    it('approve routes to the inbox ack store (no parallel store)', (t) => {
+        if (!HAVE_PY || !HAVE_BACKEND) return t.skip('python3/backend unavailable');
+        const q = cb.buildQueue(BASE, 'approval', 100);
+        const dir = q.find(it => it.title === 'Ship it');
+        assert.ok(dir, 'expected the pending approval item');
+
+        const beforeFiles = new Set(fs.readdirSync(tmp));
+        const res = cb.act(BASE, 'approve', dir.id, 'lgtm');
+        assert.strictEqual(res.status, 'approved');
+
+        // The ack landed in the EXISTING inbox_routing.jsonl — no new file.
+        const afterFiles = new Set(fs.readdirSync(tmp));
+        assert.deepStrictEqual([...afterFiles].sort(), [...beforeFiles].sort(),
+            'approve must not create a parallel approval store');
+        const routing = fs.readFileSync(path.join(tmp, 'inbox_routing.jsonl'), 'utf-8');
+        assert.match(routing, /founder_directive_completed/);
+        assert.match(routing, /"directive_subject": "Ship it"/);
+
+        // And it drops out of the pending approval queue.
+        const q2 = cb.buildQueue(BASE, 'approval', 100);
+        assert.ok(!q2.some(it => it.title === 'Ship it'));
+    });
+
+    it('approve on a non-approval class is unsupported', (t) => {
+        if (!HAVE_PY || !HAVE_BACKEND) return t.skip('python3/backend unavailable');
+        const res = cb.act(BASE, 'approve', 'att_x', '');
+        assert.strictEqual(res.status, 'unsupported');
+    });
+});


### PR DESCRIPTION
## v4.7.9 — control plane (LED-1709), Phase 0+1

- **delimit_control MCP tool** (list/get/approve/reject) — the single shared API; read-only unified queue aggregating attestations + approvals + ledger + dispatches into normalized items {id, class: attestation|approval|sensing|ops, state, title, source, created, summary, links}. Attestation lane kept distinct from the ~1170 sensing items.
- **delimit control CLI** — interactive queue browser (lanes → item → detail → approve/reject), consumes the SAME backend via a python shim (web hits it via /api/mcp — no split-brain).
- **approve/reject** route through the EXISTING inbox ack (founder_directive_completed, subject-keyed) — identical to replying 'ship it' by email; no parallel approval store; idempotent; non-approval classes return unsupported.

Additive (extends delimit_control / new CLI command). 26 gateway tests + npm tests pass; tdqs A; bundle byte-identical to the paired gateway PR. Publish gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)