### PR TITLE
perf(last_capture): seek-tail read — bundle + inline hooks (LED-1714, #9)

### DIFF
--- a/gateway/ai/last_capture.py
+++ b/gateway/ai/last_capture.py
@@ -142,12 +142,41 @@ def parse_transcript_tail(
     # Cap on how far back we scan for a real text block when the immediate
     # tail has none. Cheap: a bounded slice, no LLM, no extra IO.
     SCAN_CAP = 40
+    # Read only the trailing window of the transcript: transcripts can be many
+    # MB and this runs in time-boxed paths (Stop hook + SessionStart reconcile).
+    # 64KB comfortably holds the last ~40 lines we ever scan (SCAN_CAP) and
+    # avoids loading a multi-MB file just to read its tail.
+    TAIL_BYTES = 65536
 
     result: Dict[str, Any] = {
         "final_assistant_text": "",
         "tool_calls": [],
         "turns": 0,
     }
+
+    def _read_tail(path: Path) -> str:
+        """Read only the trailing ~TAIL_BYTES of the file (seek-from-end).
+
+        If the read started mid-file (file larger than the window), the first
+        line is a fragment and is dropped. Best-effort: on ANY failure falls
+        back to a full ``read_text`` so correctness never regresses.
+        """
+        try:
+            with open(path, "rb") as fh:
+                fh.seek(0, os.SEEK_END)
+                size = fh.tell()
+                start = max(0, size - TAIL_BYTES)
+                fh.seek(start)
+                chunk = fh.read()
+            text = chunk.decode("utf-8", errors="replace")
+            if start > 0:
+                # Drop the leading partial line — it begins mid-record.
+                nl = text.find("\n")
+                text = text[nl + 1:] if nl != -1 else ""
+            return text
+        except Exception:
+            # Fall back to the whole-file read; never regress correctness.
+            return path.read_text(errors="replace")
 
     def _extract(content: Any, tool_sink: Optional[List[str]]) -> Dict[str, str]:
         """Pull text/thinking out of one message's content blocks.
@@ -200,7 +229,7 @@ def parse_transcript_tail(
         p = Path(transcript_path)
         if not p.exists():
             return result
-        lines = [l for l in p.read_text(errors="replace").splitlines() if l.strip()]
+        lines = [l for l in _read_tail(p).splitlines() if l.strip()]
         tail = lines[-max_turns:] if max_turns > 0 else lines
         result["turns"] = len(tail)
 

--- a/lib/cross-model-hooks.js
+++ b/lib/cross-model-hooks.js
@@ -447,8 +447,26 @@ def _ex(content, sink):
     elif isinstance(content, str):
         tx.append(content)
     return "\\n".join(tx).strip(), "\\n".join(th).strip()
+def _tail_text(path):
+    # Read only the trailing ~64KB (seek-from-end): transcripts can be MB and
+    # this is a time-boxed hook. Drop the partial first line when mid-file.
+    # Best-effort: fall back to a full read so correctness never regresses.
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            start = max(0, size - 65536)
+            fh.seek(start)
+            chunk = fh.read()
+        text = chunk.decode("utf-8", errors="replace")
+        if start > 0:
+            nl = text.find("\\n")
+            text = text[nl + 1:] if nl != -1 else ""
+        return text
+    except Exception:
+        return Path(path).read_text(errors="replace")
 try:
-    tl = [l for l in Path(orphan).read_text(errors="replace").splitlines() if l.strip()]
+    tl = [l for l in _tail_text(orphan).splitlines() if l.strip()]
     tail = tl[-10:]
     turns = len(tail)
     for raw in tail:
@@ -851,9 +869,27 @@ def _ex(content, sink):
     elif isinstance(content, str):
         tx.append(content)
     return "\\n".join(tx).strip(), "\\n".join(th).strip()
+def _tail_text(path):
+    # Read only the trailing ~64KB (seek-from-end): transcripts can be MB and
+    # this is a time-boxed hook. Drop the partial first line when mid-file.
+    # Best-effort: fall back to a full read so correctness never regresses.
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            start = max(0, size - 65536)
+            fh.seek(start)
+            chunk = fh.read()
+        text = chunk.decode("utf-8", errors="replace")
+        if start > 0:
+            nl = text.find("\\n")
+            text = text[nl + 1:] if nl != -1 else ""
+        return text
+    except Exception:
+        return Path(path).read_text(errors="replace")
 try:
     if transcript_path and Path(transcript_path).exists():
-        tl = [l for l in Path(transcript_path).read_text(errors="replace").splitlines() if l.strip()]
+        tl = [l for l in _tail_text(transcript_path).splitlines() if l.strip()]
         tail = tl[-10:]
         turns = len(tail)
         for raw in tail:


### PR DESCRIPTION
Bundle + hook-generator sync of the gateway LED-1714 seek-tail optimization (paired gateway PR). `gateway/ai/last_capture.py` byte-identical to gateway; `lib/cross-model-hooks.js` SessionStart-reconcile + Stop-floor inline Python both get the `_tail_text` seek-read (rendered + py_compile verified). HELD for review; no version bump (batches into the next release with #11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)