### PR TITLE
release: v4.7.10 — handoff_preflight + test hygiene + parser tail-seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 
+## [4.7.10] - 2026-06-09
+
+Reliability + a new fail-closed handoff guard.
+
+### Added
+
+- **`delimit_handoff_preflight`** — a read-only MCP validator that checks the
+  cross-agent invariant set before a handoff/Auto-Phoenix switch (committer
+  identity not junk, repo not bare, no leaked `GIT_*`, no stale index lock,
+  recent context stamp), fail-closed. The permitted-identity allowlist is
+  configurable via `DELIMIT_GIT_IDENTITIES` (no identity baked into source).
+
+### Fixed
+
+- **Test hygiene** — git-touching tests are now hermetic and a sentinel guards
+  against any test mutating the package's `.git/config` (`core.bare`/identity).
+- **`parse_transcript_tail`** reads only the trailing ~64KB of a transcript
+  (seek-from-end) instead of loading the whole file — cheaper Stop-hook /
+  crash-recovery floor on large transcripts.
+
 ## [4.7.9] - 2026-06-09
 
 Control plane (LED-1709) — one interactive surface over the work that matters.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.7.9",
+  "version": "4.7.10",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Release commit (version + changelog) for the autonomous-afternoon batch (LED-1716): #11 .git/config pollution guard + hermetic git tests, #9 parse_transcript_tail seek-tail, #3 delimit_handoff_preflight validator (de-hardcoded identity). Feature merges already landed (#125/#126/#127 npm; #222/#223 gateway). publish.yml's sync-gateway rebuilds the bundle from the fixed gateway main at publish. Founder-approved release chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)