### PR TITLE
chore: bump proModuleVersion 3.8.2 → 3.9.0 (clean ungated Pro engine)

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "js-yaml": "^4.1.0",
     "minimatch": "^5.1.0"
   },
-  "proModuleVersion": "3.8.2",
+  "proModuleVersion": "3.9.0",
   "engines": {
     "node": ">=14.0.0"
   }


### PR DESCRIPTION
Points `delimit setup` at the published Pro-module release **v3.9.0** (live at delimit.ai/releases/v3.9.0/ — all 6 cells: linux-x86_64 + macos-arm64 × cp310/311/312).

v3.9.0 is the clean, ungated engine: Fable BYOK (no tier-gate), portfolio/anonymity anchors de-hardcoded out of the .so, absolute audit license-lock. Built + verified in CI (per-cell BYOK_MODEL_MIN_TIER=={} + bypass-guard clean).

HELD: merging alone does NOT change customer behavior — the bump reaches installs only when a new npm CLI version is **published via GitHub** (publish.yml). Merge + publish when ready to flip 3.8.2 → 3.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)