### PR TITLE
release: v4.8.0 — delimit handoff + proModuleVersion 3.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "delimit-cli",
-  "version": "4.7.5",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "delimit-cli",
-      "version": "4.7.5",
+      "version": "4.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.7.10",
+  "version": "4.8.0",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Cuts **v4.8.0**. Ships: `delimit handoff [check|fix]` + Auto-Phoenix preflight/GIT_* scrub (#129, new command → minor); proModuleVersion → **3.9.0** (#130) pointing `delimit setup` at the clean ungated Pro engine live at delimit.ai/releases/v3.9.0.

Delimit protocol gates: security_audit CLEAN · delimit doctor 9/10 · publish.yml dry-run Pre-publish Validation success + clean tarball pack (the only dry-run 'failure' was the expected can't-republish-4.7.10 version conflict, resolved by this bump).

Merge → then tag `v4.8.0` → publish.yml publishes to npm + creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)