### PR TITLE
release: v4.10.0 — Pro tier rebalance (12 free / 12 Pro w/ 90-day grace) + scan_bridge precision + grace-aware gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [4.10.0] - 2026-06-16
+
+### Changed — Pro tier rebalanced (90-day grace; no existing user is hard-cut)
+- **12 zero-marginal-cost tools moved to FREE**: the agent lifecycle (`delimit_agent_dispatch` / `_status` / `_complete` / `_handoff`), `delimit_notify`, repo inspection (`delimit_repo_analyze`, `delimit_repo_config_audit`, `delimit_repo_config_validate`), and loop/task control (`delimit_loop_config`, `delimit_loop_status`, `delimit_next_task`, `delimit_task_complete`). These are local-state / read tools that anchor the free tier.
+- **12 marginal-cost tools moved to Pro** (LLM calls, outbound network, or background daemons), each behind a **90-day grace window + automatic grandfather** so existing free users are never hard-cut mid-migration: `delimit_audit`, `delimit_build_loop_daemon`, `delimit_vendor_news_scan`, `delimit_vendor_news_draft`, `delimit_content_publish`, `delimit_social_target`, `delimit_github_scan`, `delimit_reddit_scan`, `delimit_inbox_daemon`, `delimit_social_daemon`, `delimit_daemon_run`, `delimit_notify_inbox`.
+
+### Added
+- **scan_bridge precision filter** — a data-grounded gate that cuts ~94% of low-signal strategic auto-promotions; env-tunable and reversible (`DELIMIT_SCAN_PROMO_*`).
+- Tool documentation upgrades (registry tool-score lift), a docstring-quality (TDQS) check, and secrets-broker hardening (honest at-rest field naming + kill-switched scope enforcement).
+
+### Fixed
+- The central Pro entitlement gate is now grace-aware, so newly-Pro tools honor the migration window end-to-end (no hard-block during grace).
+
 ## [4.9.0] - 2026-06-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Release vehicle for the founder-authorized publish ('go with the push'). Bumps delimit-cli 4.9.0 → 4.10.0 + CHANGELOG. Ships gateway main (#232 scan_bridge, #233 license free-cleanup + G2, #234 staged-12 + grace-aware central gate). Tag v4.10.0 after merge → publish.yml ships gateway main fresh.

Security audit clean (ev-1781649113); dry-run verified the bundle builds from main (failed only on 'cannot republish 4.9.0', the expected version guard). npm publish is the customer pricing go-live; 90-day grace means no existing user is hard-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)