### PR TITLE
release: v4.11.1 — proModuleVersion 3.10.0 (binary leaky-gate enforcement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.11.1] - 2026-06-17
+
+### Changed — compiled engine bumped to proModuleVersion 3.10.0 (binary-customer parity for LED-1454)
+- Binary (compiled-engine) installs now fetch pro module **v3.10.0**, which carries the LED-1454 leaky-gate closure into the compiled `PRO_TOOLS` set: `delimit_security_deliberate`, `delimit_security_ingest`, `delimit_gov_new_task`, and `delimit_social_approve` now require Pro on the compiled path too (previously free only there due to a set mismatch), and `delimit_repo_diagnose` + `delimit_test_coverage` are free everywhere. The four gated tools carry a **90-day grace + automatic grandfather**, so no existing free user is hard-cut mid-migration. Non-binary (Python-fallback) behavior is unchanged from 4.11.0.
+
 ## [4.11.0] - 2026-06-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [
@@ -127,7 +127,7 @@
     "js-yaml": "^4.1.0",
     "minimatch": "^5.1.0"
   },
-  "proModuleVersion": "3.9.0",
+  "proModuleVersion": "3.10.0",
   "engines": {
     "node": ">=14.0.0"
   }


### PR DESCRIPTION
Bumps proModuleVersion 3.9.0->3.10.0 so binary (compiled-engine) installs fetch the LED-1454-closed engine (4 tools enforce on the compiled path, 90-day grace; repo_diagnose/test_coverage freed). v3.10.0 .so is live + Vercel-verified at delimit.ai/releases/v3.10.0/. Founder-approved flip. **Merging does NOT publish — only the v4.11.1 tag does.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)