### PR TITLE
docs: cross-link all worked-example reports (LED-3462)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,22 @@ Every wrapped run emits a `delimit.attestation.v1` bundle: repo head before/afte
 
 ---
 
-## See it in action
+## Worked examples
 
-Worked examples, real artifacts, every claim verifiable:
+Real, reproducible merge-gate runs against public API specs:
 
-- **[Cross-agent handoff: one artifact, four CLIs](https://delimit.ai/reports/cross-agent-handoff)**: structured session handoff between Claude Code, Codex, Cursor, and Gemini CLI through a single JSON record at `~/.delimit/sessions/`. Persistent context across sessions, same artifact across four CLIs.
-- **[cal.com v2 API attestation](https://delimit.ai/reports/cal-com-v2-attestation)**: full diff, signed verdict, replayable bundle. Runs the same chain you get on day one.
+- **[OpenAI OpenAPI: a year of AI frontier evolution under a cross-vendor merge gate](https://delimit.ai/reports/openai-openapi-attestation)** — OpenAI (openai/openai-openapi)
+- **[Stripe v1 OpenAPI: 57 days under a merge gate](https://delimit.ai/reports/stripe-openapi-attestation)** — Stripe (stripe/openapi)
+- **[Anthropic API: 76 days under a cross-vendor merge gate](https://delimit.ai/reports/anthropic-api-attestation)** — Anthropic (anthropics/anthropic-sdk-python)
+- **[Twilio v2010 OpenAPI: 55 days under a merge gate](https://delimit.ai/reports/twilio-api-attestation)** — Twilio (twilio/twilio-oai)
+- **[Docusign eSignature v2.1 OpenAPI: 46 days under a merge gate](https://delimit.ai/reports/docusign-esign-attestation)** — Docusign (docusign/OpenAPI-Specifications)
+- **[Supabase Auth OpenAPI: 57 days under a merge gate](https://delimit.ai/reports/supabase-auth-openapi-attestation)** — Supabase Auth (supabase/auth)
+- **[cal.com v2 OpenAPI: 60 days under a merge gate](https://delimit.ai/reports/cal-com-v2-attestation)** — cal.com (calcom/cal.com)
+- **[EU TED v3 procurement API: $ref'd component-schema drift under a merge gate](https://delimit.ai/reports/eu-ted-v3-attestation)** — European Commission (TED v3 Public API)
+- **[Cross-agent handoff: one artifact, four CLIs](https://delimit.ai/reports/cross-agent-handoff)** — Cross-CLI session handoff (worked example)
+- **[delimit-mcp-server (self-attestation): same merge gate, third artifact class](https://delimit.ai/reports/delimit-mcp-server-tdqs)** — delimit-mcp-server (self-attestation)
 
-For the schema and signing methodology behind every report, see **[delimit.ai/methodology/mcp-attestation](https://delimit.ai/methodology/mcp-attestation)**.
+See the full index at **[delimit.ai/reports](https://delimit.ai/reports)**. For the schema and signing methodology behind every report, see **[delimit.ai/methodology/mcp-attestation](https://delimit.ai/methodology/mcp-attestation)**.
 
 ---
 


### PR DESCRIPTION
Distribution lever: the README linked only 2 of 12 live reports. Adds a Worked examples section linking all of them (delimit.ai/reports/<slug>), reusing existing report titles — no new framing. Note: npm-page README reflects at next publish; GitHub README is live on merge.