### PR TITLE
release: 4.12.1 — gemini shim → Antigravity (agy) + README refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.12.1] - 2026-06-20
+
+### Fixed
+- **Gemini governance shim routes to Antigravity (`agy`).** The generated `gemini` shim now prefers the Antigravity CLI before the retired free-tier `gemini-cli` (which returns `IneligibleTierError` as of June 2026), falling through to the real `gemini` if `agy` is not installed. Restores the generation path for users on the deprecated free tier; users without `agy` are unaffected.
+
+### Documentation
+- README now documents the zero-config `delimit check` command — the fastest path to value (PR #140).
+
 ## [4.11.1] - 2026-06-17
 
 ### Changed — compiled engine bumped to proModuleVersion 3.10.0 (binary-customer parity for LED-1454)

--- a/bin/delimit-setup.js
+++ b/bin/delimit-setup.js
@@ -785,6 +785,14 @@ WHITE='\\033[97m'; BOLD='\\033[1m'; DIM='\\033[2m'; RESET='\\033[0m'
 # Fix config permissions before anything else
 [ -f "$HOME/.codex/config.toml" ] && chmod 644 "$HOME/.codex/config.toml" 2>/dev/null
 if [ "$DELIMIT_WRAPPED" = "true" ] || [ ! -t 1 ]; then
+    # gemini-cli free tier retired (IneligibleTierError, 2026-06) -> prefer the
+    # Antigravity drop-in (agy) for gemini when installed. Falls through to the
+    # real gemini if agy is absent, so customers without agy are unaffected.
+    if [ "${toolName}" = "gemini" ]; then
+        for c in "$HOME/.local/bin/agy" /usr/local/bin/agy /usr/bin/agy; do
+            [ -x "$c" ] && exec "$c" "$@"
+        done
+    fi
     # Check for renamed binary first (avoids infinite loop when shim IS at /usr/bin/tool)
     for c in /usr/bin/${toolName}-real /usr/local/bin/${toolName}-real $HOME/.local/bin/${toolName}-real; do
         [ -x "$c" ] && exec "$c" "$@"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Patch release. (1) `delimit-setup.js`: the generated gemini governance shim now prefers the Antigravity drop-in (`agy`) before the retired free-tier gemini-cli (IneligibleTierError), falling through to the real gemini if agy is absent — agy-less customers unaffected (LED-3483). (2) README now documents the zero-config `delimit check` command (was missing on npm). (3) CHANGELOG + version 4.12.0→4.12.1. Gates: security clean, 245 tests pass, doctor 12✓, tdqs grade A.