### PR TITLE
chore(publish): clean-tree publish gate (STR-2169 D2, rebased on main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
     "sync-gateway": "bash scripts/sync-gateway.sh",
-    "prepublishOnly": "bash scripts/publish-ci-guard.sh && npm run sync-gateway && bash scripts/build-license-core.sh && bash scripts/security-check.sh",
+    "prepublishOnly": "node scripts/clean-tree-guard.js && bash scripts/publish-ci-guard.sh && npm run sync-gateway && bash scripts/build-license-core.sh && bash scripts/security-check.sh",
     "test": "node scripts/test-with-config-guard.js",
-    "test:raw": "node --test tests/_config-sentinel.test.js tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js tests/auth-signin.test.js tests/auth-signout.test.js tests/migration-2092-banner.test.js tests/control-browser.test.js"
+    "test:raw": "node --test tests/clean-tree-guard.test.js tests/_config-sentinel.test.js tests/setup-onboarding.test.js tests/setup-matrix.test.js tests/setup-no-clobber.test.js tests/config-export-import.test.js tests/cross-model-hooks.test.js tests/golden-path.test.js tests/v420-features.test.js tests/v43-wrap-engine.test.js tests/v43-trust-page-engine.test.js tests/v43-ai-sbom-engine.test.js tests/attest-mcp.test.js tests/delimit-home.test.js tests/postinstall-hardening.test.js tests/auth-signin.test.js tests/auth-signout.test.js tests/migration-2092-banner.test.js tests/control-browser.test.js"
   },
   "keywords": [
     "openapi",

--- a/scripts/clean-tree-guard.js
+++ b/scripts/clean-tree-guard.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Clean-tree publish gate (DRAFT-D2 / STR-2169, Wave 1).
+ *
+ * Makes it IMPOSSIBLE to `npm publish` from a dirty working tree, so that
+ * uncommitted or untracked code can never ship to customers invisibly.
+ *
+ * Wired as the FIRST step of `prepublishOnly` in package.json — it runs
+ * BEFORE sync-gateway / build-license-core, which intentionally mutate the
+ * tree (rsync gateway files, generate the license_core .so). By checking
+ * cleanliness first, the gate asserts that the committed state is exactly
+ * what will be built and published.
+ *
+ * In CI the checkout is a fresh clone, so the tree is clean at this point and
+ * the gate is a no-op. Locally, a dirty tree blocks the publish.
+ *
+ * Emergency override: set DELIMIT_ALLOW_DIRTY_PUBLISH=1 to bypass. This is
+ * for hotfixes only and prints a loud warning so the bypass is never silent.
+ *
+ * The core decision logic is exported as a pure function (`evaluateCleanTree`)
+ * so it can be unit-tested with a stubbed git-status string.
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+const OVERRIDE_ENV = 'DELIMIT_ALLOW_DIRTY_PUBLISH';
+
+/**
+ * Pure decision function — no I/O, fully testable.
+ *
+ * @param {Object} opts
+ * @param {string} opts.porcelain  Raw output of `git status --porcelain`.
+ * @param {boolean} opts.allowDirty  Whether the emergency override is set.
+ * @returns {{ blocked: boolean, exitCode: number, message: string, override: boolean }}
+ */
+function evaluateCleanTree({ porcelain, allowDirty }) {
+  const dirty = typeof porcelain === 'string' && porcelain.trim().length > 0;
+
+  if (!dirty) {
+    return {
+      blocked: false,
+      exitCode: 0,
+      override: false,
+      message: 'Clean-tree gate: working tree is clean — OK to publish.',
+    };
+  }
+
+  // Tree is dirty.
+  const entries = porcelain
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 0);
+  const listing = entries.map((e) => `    ${e}`).join('\n');
+
+  if (allowDirty) {
+    return {
+      blocked: false,
+      exitCode: 0,
+      override: true,
+      message:
+        `WARNING: ${OVERRIDE_ENV}=1 — publishing from a DIRTY tree by override.\n` +
+        `The following uncommitted/untracked changes will be baked into the package:\n` +
+        `${listing}\n` +
+        `This bypass is for emergency hotfixes only. Prefer committing first.`,
+    };
+  }
+
+  return {
+    blocked: true,
+    exitCode: 1,
+    override: false,
+    message:
+      `PUBLISH BLOCKED — working tree is dirty (${entries.length} change(s)).\n` +
+      `Uncommitted or untracked files would ship to customers invisibly:\n` +
+      `${listing}\n\n` +
+      `Fix: commit or stash your changes, then publish from a clean tree.\n` +
+      `Emergency override (hotfix only): ${OVERRIDE_ENV}=1 npm publish`,
+  };
+}
+
+function readPorcelain(cwd) {
+  return execSync('git status --porcelain', {
+    cwd,
+    encoding: 'utf-8',
+  });
+}
+
+function main() {
+  // Package dir is the parent of scripts/.
+  const pkgDir = path.resolve(__dirname, '..');
+
+  let porcelain;
+  try {
+    porcelain = readPorcelain(pkgDir);
+  } catch (err) {
+    // Not a git repo (e.g. installed tarball) — nothing to gate. Do not block.
+    console.log(
+      'Clean-tree gate: not a git working tree — skipping (nothing to gate).'
+    );
+    process.exit(0);
+  }
+
+  const allowDirty = process.env[OVERRIDE_ENV] === '1';
+  const result = evaluateCleanTree({ porcelain, allowDirty });
+
+  if (result.blocked) {
+    console.error('');
+    console.error(result.message);
+    console.error('');
+    process.exit(result.exitCode);
+  }
+
+  console.log(result.message);
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { evaluateCleanTree, OVERRIDE_ENV };

--- a/tests/clean-tree-guard.test.js
+++ b/tests/clean-tree-guard.test.js
@@ -1,0 +1,69 @@
+/**
+ * Tests for the clean-tree publish gate (DRAFT-D2 / STR-2169, Wave 1).
+ *
+ * Proves the gate blocks a dirty working tree and passes on a clean one,
+ * plus the emergency override behaviour. Uses a stubbed `git status
+ * --porcelain` string so the test is deterministic and does not touch the
+ * real repo state.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { evaluateCleanTree, OVERRIDE_ENV } = require('../scripts/clean-tree-guard');
+
+describe('clean-tree publish gate', () => {
+  it('PASSES on a clean tree (empty porcelain)', () => {
+    const r = evaluateCleanTree({ porcelain: '', allowDirty: false });
+    assert.strictEqual(r.blocked, false);
+    assert.strictEqual(r.exitCode, 0);
+    assert.strictEqual(r.override, false);
+    assert.match(r.message, /clean/i);
+  });
+
+  it('PASSES on a whitespace-only porcelain (treated as clean)', () => {
+    const r = evaluateCleanTree({ porcelain: '\n  \n', allowDirty: false });
+    assert.strictEqual(r.blocked, false);
+    assert.strictEqual(r.exitCode, 0);
+  });
+
+  it('BLOCKS on a dirty tree with modified + untracked files', () => {
+    const porcelain = [
+      ' M gateway/ai/server.js',
+      '?? lib/new-thing.js',
+    ].join('\n');
+    const r = evaluateCleanTree({ porcelain, allowDirty: false });
+    assert.strictEqual(r.blocked, true, 'dirty tree must block');
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.message, /PUBLISH BLOCKED/);
+    // The offending files must be surfaced in the message.
+    assert.match(r.message, /gateway\/ai\/server\.js/);
+    assert.match(r.message, /lib\/new-thing\.js/);
+    // The count must be reported.
+    assert.match(r.message, /2 change/);
+  });
+
+  it('BLOCKS on a single untracked file', () => {
+    const r = evaluateCleanTree({ porcelain: '?? secret.js', allowDirty: false });
+    assert.strictEqual(r.blocked, true);
+    assert.strictEqual(r.exitCode, 1);
+  });
+
+  it('allows publish under the documented emergency override', () => {
+    const porcelain = ' M gateway/ai/server.js';
+    const r = evaluateCleanTree({ porcelain, allowDirty: true });
+    assert.strictEqual(r.blocked, false, 'override must not block');
+    assert.strictEqual(r.exitCode, 0);
+    assert.strictEqual(r.override, true);
+    // Override path must warn loudly and still list what ships.
+    assert.match(r.message, /WARNING/);
+    assert.match(r.message, /gateway\/ai\/server\.js/);
+    assert.ok(r.message.includes(OVERRIDE_ENV));
+  });
+
+  it('override on a clean tree is a normal clean pass (no warning)', () => {
+    const r = evaluateCleanTree({ porcelain: '', allowDirty: true });
+    assert.strictEqual(r.blocked, false);
+    assert.strictEqual(r.override, false);
+    assert.doesNotMatch(r.message, /WARNING/);
+  });
+});


### PR DESCRIPTION
## What

Adds a clean-tree publish gate: `npm publish` is blocked from a dirty working tree so uncommitted or untracked code can never ship to customers invisibly.

- `scripts/clean-tree-guard.js` (new) — pure `evaluateCleanTree()` + CLI wrapper. Runs `git status --porcelain`; blocks with a clear message + file listing when dirty. No-op outside a git tree (installed tarball).
- `tests/clean-tree-guard.test.js` (new) — 6 cases (clean pass, whitespace-clean, dirty block, single-untracked block, override, clean-override), wired into `test:raw` first.
- `package.json` — `prepublishOnly` runs `node scripts/clean-tree-guard.js` as the FIRST step (before sync-gateway / build-license-core, which mutate the tree). Emergency override: `DELIMIT_ALLOW_DIRTY_PUBLISH=1`.

## Why this supersedes #145

PR #145 (branch `chore/npm-clean-tree-gate`) was mis-based on `release/v4.14.0`, which is divergent from main and drags in an unrelated broken StateValidator deletion (`governance_hardening.py` removed `StateValidator` while `test_state_validator.py` still imports it → ImportError), so its CI is red.

This branch is cut fresh from `main` and carries **ONLY** the 3 clean-tree-gate changes. Everything else from the old base is excluded: no StateValidator deletion, no license_core drop, no playwright_sandbox addition, no secrets_broker edit, no v4.14.1 version bump.

## Verification

- Guard unit test: 6/6 pass.
- Full `test:raw`: 304 tests / 250 pass / 51 fail — the 51 failures are pre-existing on `main` (identical count on a clean main baseline; environment-dependent: npm audit unavailable, temp dirs, browser tooling). This branch adds only the 6 new passing guard tests and introduces zero new failures.
- Manual: dirty tree → blocked (exit 1); `DELIMIT_ALLOW_DIRTY_PUBLISH=1` → passes (exit 0); clean tree → passes.

Part of STR-2169. Do not merge without founder review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)