### PR TITLE
fix(publish): clean-tree guard allows publish-time version bump

### DIFF
--- a/scripts/clean-tree-guard.js
+++ b/scripts/clean-tree-guard.js
@@ -28,6 +28,31 @@ const path = require('path');
 
 const OVERRIDE_ENV = 'DELIMIT_ALLOW_DIRTY_PUBLISH';
 
+// Files that are LEGITIMATELY dirty at publish time. `npm version` /
+// delimit_deploy_npm bump the version in package.json (and re-lock
+// package-lock.json) IN PLACE before npm runs prepublishOnly, so the guard
+// would otherwise see the expected version bump as "dirty" and false-block the
+// publish. These are the ONLY paths allowed to be dirty — any other modified or
+// untracked file still blocks (that's the stray-uncommitted-code the gate
+// exists to catch).
+const VERSION_BUMP_ALLOWLIST = new Set(['package.json', 'package-lock.json']);
+
+/**
+ * Extract the file path from a single `git status --porcelain` (v1) line.
+ * Porcelain v1 format is `XY <path>` — two status columns, a space, then the
+ * path. Renames/copies use `XY <old> -> <new>`; for those we use the new path
+ * (the destination), which is what matters for what would ship.
+ *
+ * @param {string} entry  A trimmed porcelain line (leading space preserved).
+ * @returns {string} The file path.
+ */
+function porcelainPath(entry) {
+  // Status is the first two chars, then a separator space, then the path.
+  const raw = entry.slice(3);
+  const arrow = raw.indexOf(' -> ');
+  return arrow === -1 ? raw : raw.slice(arrow + 4);
+}
+
 /**
  * Pure decision function — no I/O, fully testable.
  *
@@ -48,11 +73,31 @@ function evaluateCleanTree({ porcelain, allowDirty }) {
     };
   }
 
-  // Tree is dirty.
-  const entries = porcelain
+  // All non-empty porcelain lines.
+  const allEntries = porcelain
     .split('\n')
     .map((l) => l.trimEnd())
     .filter((l) => l.length > 0);
+
+  // Filter out the legitimate publish-time version bump (package.json /
+  // package-lock.json). Only the REMAINING entries count toward dirtiness.
+  const entries = allEntries.filter(
+    (e) => !VERSION_BUMP_ALLOWLIST.has(porcelainPath(e))
+  );
+
+  // If the only changes were the version-bump files, the tree is effectively
+  // clean for publish purposes.
+  if (entries.length === 0) {
+    return {
+      blocked: false,
+      exitCode: 0,
+      override: false,
+      message:
+        'Clean-tree gate: only the publish-time version bump ' +
+        '(package.json / package-lock.json) is dirty — OK to publish.',
+    };
+  }
+
   const listing = entries.map((e) => `    ${e}`).join('\n');
 
   if (allowDirty) {

--- a/tests/clean-tree-guard.test.js
+++ b/tests/clean-tree-guard.test.js
@@ -42,6 +42,41 @@ describe('clean-tree publish gate', () => {
     assert.match(r.message, /2 change/);
   });
 
+  it('PASSES when only package.json is dirty (publish-time version bump)', () => {
+    const r = evaluateCleanTree({ porcelain: ' M package.json', allowDirty: false });
+    assert.strictEqual(r.blocked, false, 'lone version bump must not block');
+    assert.strictEqual(r.exitCode, 0);
+    assert.strictEqual(r.override, false);
+    assert.match(r.message, /version bump/i);
+  });
+
+  it('PASSES when package.json + package-lock.json are dirty (version bump)', () => {
+    const porcelain = [
+      ' M package.json',
+      ' M package-lock.json',
+    ].join('\n');
+    const r = evaluateCleanTree({ porcelain, allowDirty: false });
+    assert.strictEqual(r.blocked, false, 'version bump pair must not block');
+    assert.strictEqual(r.exitCode, 0);
+    assert.strictEqual(r.override, false);
+  });
+
+  it('BLOCKS when a stray file is dirty alongside the version bump', () => {
+    const porcelain = [
+      ' M package.json',
+      ' M package-lock.json',
+      ' M lib/stray.js',
+    ].join('\n');
+    const r = evaluateCleanTree({ porcelain, allowDirty: false });
+    assert.strictEqual(r.blocked, true, 'stray file must still block');
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.message, /PUBLISH BLOCKED/);
+    // Only the stray file is surfaced/counted — the version bump is excluded.
+    assert.match(r.message, /lib\/stray\.js/);
+    assert.doesNotMatch(r.message, /package\.json/);
+    assert.match(r.message, /1 change/);
+  });
+
   it('BLOCKS on a single untracked file', () => {
     const r = evaluateCleanTree({ porcelain: '?? secret.js', allowDirty: false });
     assert.strictEqual(r.blocked, true);


### PR DESCRIPTION
## Problem

`scripts/clean-tree-guard.js` runs first in `prepublishOnly` and fails if `git status --porcelain` is non-empty. But `npm version` / `delimit_deploy_npm` bump `package.json` + `package-lock.json` **in place** before npm runs `prepublishOnly`, so the guard sees the legitimate version bump as "dirty" and false-blocks the publish:

```
PUBLISH BLOCKED — working tree is dirty (2 change(s)):
    M package.json
    M package-lock.json
```

The guard's purpose is to catch **stray uncommitted code**, not the expected publish-time version bump. This blocks the 4.14.2 publish.

## Fix

Filter `package.json` and `package-lock.json` out of the porcelain lines before deciding dirty/clean (`VERSION_BUMP_ALLOWLIST`):
- Tree whose **only** changes are those files → **PASS** (that's the version bump).
- **Any other** modified/untracked file → still **BLOCK** (and only the stray files are surfaced/counted).
- Pure/testable `evaluateCleanTree` structure and the `DELIMIT_ALLOW_DIRTY_PUBLISH` override are preserved.
- Rename-aware path extraction (`XY <old> -> <new>` uses the destination path).

## Tests

`tests/clean-tree-guard.test.js` — added:
- only `package.json` dirty → PASS
- `package.json` + `package-lock.json` dirty → PASS
- `package.json` + `package-lock.json` + stray `.js` → still BLOCK (only the stray file counted)

Existing clean/dirty/override cases stay green. Full suite: **302/302 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)