### PR TITLE
docs(npm): on-promise package description (LED-3700, STR-2195)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
   "version": "4.15.0",
-  "description": "Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.",
+  "description": "The merge gate for AI-written code, with signed, replayable attestation. Works with Claude Code, Codex, Cursor, and Gemini CLI.",
   "main": "index.js",
   "files": [
     "bin/",


### PR DESCRIPTION
Founder-ratified 2026-07-07 (in-session). One-line `package.json` `description` fix.

**Change**
```
- Unify Claude Code, Codex, Cursor, and Gemini CLI with persistent context, governance, and multi-model debate.
+ The merge gate for AI-written code, with signed, replayable attestation. Works with Claude Code, Codex, Cursor, and Gemini CLI.
```

**Why:** the npm `description` is the line npm shows in search results / package header / registry embeds — the actual first touch — and it had drifted off-promise (banned `unify/workspace` framing). New copy leads with the locked external promise verbatim and keeps the cross-vendor assistant list (STR-2195: cross-vendor is now canonical public wording; distribution doctrine: name the assistants).

**Ship path:** rides the **next regular release** publish-gate chain (security_audit → test_smoke → changelog → deploy_plan). **No out-of-band publish** — per founder directive. README already on-promise (no change needed).

Refs: LED-3700, STR-2195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)