### PR TITLE
Glama coherence: DELIMIT_TOOLSET=core Docker pin + server.json version-sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,20 @@ COPY gateway/ ./gateway/
 
 ENV PYTHONPATH=/app/gateway:/app/gateway/ai
 
+# Pin the containerized MCP surface to the coherent "core" profile (~24 tools)
+# instead of the full ~200-tool surface. This image is ONLY the crawler surface
+# for MCP directories (e.g. Glama), which build this Dockerfile and count the
+# tools the RUNNING server exposes. A curated set scores far better on
+# directory "tool count" / coherence rubrics and is actually triable.
+#
+# NON-BREAKING for installed users: npm/local users never launch via this
+# Dockerfile — they run the CLI-managed server with DELIMIT_TOOLSET UNSET, which
+# resolves to "full" (byte-identical to the historical surface; DEFAULT_TOOLSET
+# is "full"). No tool is removed or renamed; all tools remain registered under
+# "full" and every tool stays importable/callable internally regardless of
+# profile. The mechanism (LED-3709) is registration-gating only. An unknown or
+# unset value fails safe to "full".
+ENV DELIMIT_TOOLSET=core
+
 # MCP server runs via stdio
 ENTRYPOINT ["python", "gateway/ai/server.py"]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -91,12 +91,34 @@ echo ""
 echo "[4/5] Bumping version to $VERSION..."
 npm version "$VERSION" --no-git-tag-version
 
+# Keep server.json (MCP registry manifest) in lockstep with package.json.
+# Without this, server.json.version drifts behind the published npm version
+# (it lagged at 4.7.3 while package.json was 4.15.0 — LED-3717), which hurts
+# MCP-directory freshness/completeness scoring. Updates both the top-level
+# version and the npm package entry.
+if [ -f server.json ]; then
+    echo "  Syncing server.json version -> $VERSION"
+    node -e '
+        const fs = require("fs");
+        const v = require("./package.json").version;
+        const p = "server.json";
+        const s = JSON.parse(fs.readFileSync(p, "utf8"));
+        s.version = v;
+        if (Array.isArray(s.packages)) {
+            for (const pkg of s.packages) {
+                if (pkg && typeof pkg === "object") pkg.version = v;
+            }
+        }
+        fs.writeFileSync(p, JSON.stringify(s, null, 2) + "\n");
+    '
+fi
+
 # ── Step 5: Commit, tag, and push ────────────────────────────────────
 echo ""
 echo "[5/5] Committing and tagging..."
 
 # Stage synced gateway files too (sync-gateway may have updated them)
-git add package.json package-lock.json gateway/
+git add package.json package-lock.json server.json gateway/
 
 # Use a release branch to avoid main branch protection
 RELEASE_BRANCH="release/v$VERSION"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/delimit-ai/delimit-mcp-server",
     "source": "github"
   },
-  "version": "4.7.3",
+  "version": "4.15.0",
   "websiteUrl": "https://delimit.ai",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "delimit-cli",
-      "version": "4.7.3",
+      "version": "4.15.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Fable Glama analysis (mem-ac4dba64565e). NON-BREAKING, STAGED — founder reviews + claims the Glama listing. (1) Dockerfile ENV DELIMIT_TOOLSET=core → Glama's crawler sees the coherent 24-tool core profile (Tool Count 1/5→~4/5, Server Coherence C→A). Installs launch via CLI env-unset → full (~215 tools, byte-identical) — no tool removed, no install affected. (2) server.json 4.7.3→4.15.0 (LED-3717 drift) + version-sync guard in release.sh. glama.json unchanged (schema only defines maintainers; rich metadata = Glama-dashboard fields, founder-gated claim). FOUNDER-GATED (not here): impl-alias public names, minimal profile, new-install default flip. ⚠️ NOTE: pin is INERT until the committed gateway/ bundle carries LED-3709 (bundle predates it) — activates on next release/bundle-refresh; AND sync-gateway.sh EXCLUDE list is incomplete vs package.json block-list (proprietary-leak risk — fix before bundle refresh).