### PR TITLE
ci: fail-closed identity-guard (block non-anonymized commit identities)

### DIFF
--- a/.github/IDENTITY_GUARD.md
+++ b/.github/IDENTITY_GUARD.md
@@ -1,0 +1,75 @@
+# Identity Guard
+
+`.github/workflows/identity-guard.yml` is a **fail-closed CI check** that stops any
+commit carrying a non-anonymized git identity from landing on this repository.
+
+## Why
+
+This is a **public** repository. Commits expose their git **author** and **committer**
+email addresses forever, and GitHub's squash-merge preserves the author email of the
+merged PR. A personal or org email on a public commit is a permanent, irreversible
+identity leak. Local git hooks can be bypassed (`--no-verify`) and ephemeral CI /
+agent worktrees can be misconfigured, so this enforcement lives **server-side in CI**
+where it cannot be skipped.
+
+## What it does
+
+On every `pull_request` and `push`, the guard enumerates the git author **and**
+committer email of every commit in the range and fails the job if any email is not
+on the allowlist. On failure it prints the offending commit SHA and a **redacted**
+email (local-part masked, e.g. `***@example.com`) — never the full address.
+
+**Allowlist (only these pass):**
+
+| Pattern | Example |
+| --- | --- |
+| `*@users.noreply.github.com` | `12345678+octocat@users.noreply.github.com` |
+| `*@delimit.ai` | `team@delimit.ai` |
+| GitHub system committer (exact) | `noreply@github.com`, `actions@github.com` |
+
+The GitHub system identities are exempt because GitHub itself sets them on
+squash-merges, merge commits, and web-UI edits — they are public, non-personal, and
+without the exemption every legitimate squash-merge would fail the check.
+
+The guard uses **pure bash + git only** — zero external actions or dependencies
+beyond `actions/checkout`.
+
+## How to fix a flagged commit
+
+First, set an anonymized email for future commits (get your GitHub noreply address
+from GitHub → Settings → Emails → "Keep my email addresses private"):
+
+```bash
+git config user.email 'ID+USERNAME@users.noreply.github.com'
+```
+
+Then rewrite the flagged commit(s):
+
+- **Tip commit only:**
+  ```bash
+  git commit --amend --author='NAME <ID+USERNAME@users.noreply.github.com>' --reset-author
+  ```
+- **Older commits in the branch:**
+  ```bash
+  git rebase -i <base-sha>     # mark each flagged commit 'edit'
+  # at each stop:
+  git commit --amend --author='NAME <ID+USERNAME@users.noreply.github.com>' --reset-author
+  git rebase --continue
+  ```
+- Force-push **your own feature branch** (never a shared/protected branch) and let CI re-run.
+
+To rewrite author **and** committer across a whole branch in one shot:
+
+```bash
+git rebase <base-sha> \
+  --exec "git commit --amend --no-edit --reset-author \
+          --author='NAME <ID+USERNAME@users.noreply.github.com>'"
+```
+
+## Scope / non-goals
+
+- The guard is **additive**: it does not modify any other workflow, read any secret,
+  or change repository runtime behavior.
+- Making this a **required** status check (so a red guard blocks merge) is a
+  branch-protection / ruleset change and is intentionally **not** performed by the
+  guard itself — that is a separate, deliberate repo-settings decision.

--- a/.github/workflows/identity-guard.yml
+++ b/.github/workflows/identity-guard.yml
@@ -1,0 +1,112 @@
+name: identity-guard
+
+# Fail-closed CI guard (SHIFT-1 anonymity): blocks any commit whose git AUTHOR
+# or COMMITTER email is not an anonymized identity from landing on this public
+# repo. Local git hooks are bypassable; this runs server-side in CI.
+# Allowed: *@users.noreply.github.com, *@delimit.ai, and GitHub's own system
+# committer identities (noreply@github.com / actions@github.com).
+# Rationale + how to fix a flagged commit: .github/IDENTITY_GUARD.md
+# ADDITIVE — does not read secrets, alter any existing workflow, or change runtime.
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  identity-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Enforce anonymized commit identities
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          # identity-guard core logic (canonical). Pure bash + git, zero external deps.
+          # Consumed inline by .github/workflows/identity-guard.yml in each public repo.
+          # Env inputs (any subset):
+          #   PR_BASE_SHA / PR_HEAD_SHA  -> pull_request range
+          #   PUSH_BEFORE / PUSH_AFTER   -> push range
+          #   DEFAULT_BRANCH             -> repo default branch (fallback base for new branches)
+          set -euo pipefail
+          
+          ZERO="0000000000000000000000000000000000000000"
+          # ALLOWLIST ONLY. No personal emails ever appear in this file (denylist-by-omission).
+          # Anonymized-identity domains: GitHub noreply (per-user) and the delimit.ai org domain.
+          ALLOW_SUFFIXES=("@users.noreply.github.com" "@delimit.ai")
+          # GitHub's own system committer identities. These are set by GitHub itself on
+          # squash-merges, merge commits, and web-UI edits (committer "GitHub"). They are
+          # public, non-personal, and cannot deanonymize the founder. Without this a strict
+          # suffix allowlist would fail EVERY legitimate squash-merge to a protected branch.
+          ALLOW_EXACT=("noreply@github.com" "actions@github.com")
+          
+          range_commits() {
+            if [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; then
+              git rev-list "${PR_BASE_SHA}..${PR_HEAD_SHA}"
+            elif [ -n "${PUSH_BEFORE:-}" ] && [ "${PUSH_BEFORE}" != "$ZERO" ] && [ -n "${PUSH_AFTER:-}" ] && [ "${PUSH_AFTER}" != "$ZERO" ]; then
+              git rev-list "${PUSH_BEFORE}..${PUSH_AFTER}"
+            else
+              # New branch / first push / unknown "before": commits on the tip that are
+              # not already reachable from the default branch; else fall back to the tip.
+              local tip base
+              tip="${PUSH_AFTER:-HEAD}"
+              base="$(git rev-parse --verify --quiet "origin/${DEFAULT_BRANCH:-main}" || true)"
+              if [ -n "$base" ]; then
+                git rev-list "${base}..${tip}"
+              else
+                git rev-list -n 50 "$tip"
+              fi
+            fi
+          }
+          
+          allowed() {
+            local email="$1" suf exact
+            for exact in "${ALLOW_EXACT[@]}"; do
+              [ "$email" = "$exact" ] && return 0
+            done
+            for suf in "${ALLOW_SUFFIXES[@]}"; do
+              case "$email" in
+                *"$suf") return 0 ;;
+              esac
+            done
+            return 1
+          }
+          
+          fail=0
+          checked=0
+          while read -r sha; do
+            [ -z "$sha" ] && continue
+            checked=$((checked + 1))
+            # role-tagged: A=author, C=committer
+            while IFS='|' read -r role email; do
+              if ! allowed "$email"; then
+                domain="${email##*@}"
+                [ "$domain" = "$email" ] && domain="(none)"   # no '@' present
+                echo "::error::Commit ${sha} ${role} identity is not anonymized: ***@${domain}"
+                fail=1
+              fi
+            done < <(git show -s --format='A|%ae%nC|%ce' "$sha")
+          done < <(range_commits)
+          
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "identity-guard FAILED: one or more commits carry a non-anonymized identity."
+            echo "Allowed author/committer emails must end in: @users.noreply.github.com or @delimit.ai"
+            echo "Fix a flagged commit before it can merge:"
+            echo "  - Set your GitHub noreply email:  git config user.email 'ID+USERNAME@users.noreply.github.com'"
+            echo "  - Amend the tip commit:           git commit --amend --author='NAME <ID+USERNAME@users.noreply.github.com>' --reset-author"
+            echo "  - Rewrite older commits:          git rebase -i <base>  (mark commits 'edit', amend each)"
+            echo "  - Then force-push YOUR feature branch (never a shared branch) and re-run."
+            exit 1
+          fi
+          
+          echo "identity-guard OK: ${checked} commit(s) checked; all author/committer identities are anonymized."


### PR DESCRIPTION
## What
Adds a **fail-closed CI check** (`.github/workflows/identity-guard.yml`) that blocks any commit whose git **author or committer** email is not anonymized from landing on this public repo (source of the published `delimit-cli` npm package).

- Runs on `pull_request` + `push`; enumerates every commit in the range.
- **Allowlist only:** `*@users.noreply.github.com`, `*@delimit.ai`, plus GitHub's own system committer identities (`noreply@github.com`, `actions@github.com`).
- On failure: prints the offending SHA + a **redacted** email (`***@example.com`). Never prints full PII.
- **Pure bash + git, zero external deps** beyond `actions/checkout`.

## Why
Squash-merge preserves the PR author email in public history; a personal email there is a permanent identity leak. Local hooks are bypassable, so this is enforced server-side.

## Scope
ADDITIVE only — no existing workflow modified, no history rewrite, no force-push, no branch-protection change. Making this a **required** status check is a separate ruleset change and is **not** included here.

## Local test proof
gmail-authored range → FAIL (exit 1, `***@gmail.com`); all-noreply/`@delimit.ai` range → PASS; simulated squash-merge (committer `noreply@github.com`) → PASS; gmail author behind a system committer → still FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)