### PR TITLE
feat(chat): launch pre-brief + honest launcher naming (Fable doc-33)

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -7274,10 +7274,21 @@ program
     });
 
 
-// --- Chat command (Native REPL) ---
+// --- Chat command (governed session launcher / Auto-Phoenix) ---
+// Despite the name, this is NOT a chat surface: it is a governed session
+// launcher with quota fallback + soul revive (reads the models.json fallback
+// chain, probes quota, spawns the model shim, and on quota death captures the
+// soul and relaunches the next model with revive). See Fable doc-33.
+//
+// `phoenix` is an honest additional alias (the launcher's internal name is
+// "Auto-Phoenix"). NOTE: `session` was the originally-requested alias but a
+// distinct `session` command already exists (native session-shell); aliasing
+// to it throws at commander registration and would crash the whole CLI, so it
+// is intentionally NOT used here. `chat` behavior is unchanged.
 program
     .command('chat')
-    .description('Start the native Delimit interactive chat REPL')
+    .alias('phoenix')
+    .description('Governed session launcher: quota fallback + soul revive across models (Auto-Phoenix). Alias: phoenix')
     .option('--api-fallback', 'Enable API fallback to continue using paid tokens')
     .action((options) => {
         const { DelimitChatREPL } = require('../lib/chat-repl');

--- a/lib/chat-repl.js
+++ b/lib/chat-repl.js
@@ -102,6 +102,84 @@ class DelimitChatREPL {
         return null;
     }
 
+    // Fable doc-33 (33_FABLE_CONTROL_PLANE_TUI.md §3): launch pre-brief.
+    // `delimit chat` used to launch BLIND — the founder had 39 items waiting in
+    // `delimit control` and no way to know at entry. This surfaces the org's
+    // state at every session entry (and between quota migrations).
+    //
+    // Sourced from the read-only control-plane aggregator (ai/control_plane.py)
+    // via the SAME python-shim pattern captureSoulForMigration/preflightHandoff
+    // already use (bundled gateway first, then the installed ~/.delimit/server).
+    //
+    // HARD non-blocking contract: the probe is capped at 1.5s and fully wrapped
+    // in try/catch. On ANY failure/timeout/empty result it returns null and the
+    // caller prints nothing — it must NEVER delay or block the session launch,
+    // and it adds NO network call and NO new dependency.
+    getControlBrief() {
+        const candidates = [
+            path.join(__dirname, '..', 'gateway'),
+            path.join(os.homedir(), '.delimit', 'server'),
+        ];
+        for (const base of candidates) {
+            if (!fs.existsSync(path.join(base, 'ai', 'control_plane.py'))) continue;
+            try {
+                // Source the three counts through the read-only control_plane
+                // helpers (present in both the bundle and the installed server)
+                // plus the same raw stores the corp dashboard reads — so the
+                // numbers are HONEST: approvals = pending founder directives
+                // (dedup-by-subject), agents = dispatched agent-queue tasks
+                // (NOT ledger ops), p0s = OPEN P0 central-ledger items.
+                const pyCmd = `import sys, json; sys.path.insert(0, ${JSON.stringify(base)}); `
+                    + `from ai.control_plane import _delimit_home, _iter_jsonl, _load_approvals; `
+                    + `home = _delimit_home(); `
+                    + `approvals = len(_load_approvals()); `
+                    + `agents = 0; tp = home / "agents" / "tasks.json"; `
+                    + `_running = ("dispatched", "in_progress", "handed_off"); `
+                    + `\ntry:\n`
+                    + ` if tp.exists():\n`
+                    + `  tasks = json.loads(tp.read_text())\n`
+                    + `  if isinstance(tasks, dict):\n`
+                    + `   agents = sum(1 for t in tasks.values() if isinstance(t, dict) and str(t.get("status", "")).lower() in _running)\n`
+                    + `except Exception:\n pass\n`
+                    + `p0s = 0; ld = home / "ledger"\n`
+                    + `if ld.is_dir():\n`
+                    + ` for p in ld.glob("*.jsonl"):\n`
+                    + `  for row in _iter_jsonl(p):\n`
+                    + `   st = str(row.get("status", "")).lower()\n`
+                    + `   if st in ("open", "in_progress", "in-progress", "active") and str(row.get("priority", "")).upper() == "P0":\n`
+                    + `    p0s += 1\n`
+                    + `print(json.dumps({"approvals": approvals, "agents": agents, "p0s": p0s}))`;
+                const r = spawnSync('python3', ['-c', pyCmd], { encoding: 'utf-8', timeout: 1500 });
+                if (r.status === 0 && r.stdout) {
+                    const brief = JSON.parse(r.stdout.trim());
+                    if (brief && typeof brief === 'object') return brief;
+                }
+            } catch (e) { /* best-effort; try next candidate, else give up silently */ }
+        }
+        return null;
+    }
+
+    // Print the one-line launch pre-brief. Entirely best-effort: if the backend
+    // is unreachable/slow/empty this prints NOTHING and the launch proceeds
+    // normally. Never throws to the caller.
+    printLaunchPrebrief() {
+        try {
+            const brief = this.getControlBrief();
+            if (!brief) return;
+            const approvals = Number(brief.approvals) || 0;
+            const agents = Number(brief.agents) || 0;
+            const p0s = Number(brief.p0s) || 0;
+            const plur = (n, w) => `${n} ${w}${n === 1 ? '' : 's'}`;
+            const line = `${plur(approvals, 'approval')} waiting · `
+                + `${plur(agents, 'agent')} running · `
+                + `${plur(p0s, 'P0')} open`;
+            console.log(chalk.cyan(`  ⎿ ${line}`));
+            if (approvals > 0) {
+                console.log(chalk.gray(`     run \`delimit control\` to triage the ${approvals} awaiting you`));
+            }
+        } catch (e) { /* pre-brief is best-effort; never block the session */ }
+    }
+
     start() {
                 console.log(chalk.magenta.bold(`
   ██████╗ ███████╗██╗     ██╗███╗   ███╗██╗████████╗
@@ -125,6 +203,9 @@ class DelimitChatREPL {
         for (const v of ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY', 'GIT_COMMON_DIR', 'GIT_QUARANTINE_PATH']) {
             delete process.env[v];
         }
+
+        // Fable doc-33: surface the control plane at session entry (best-effort).
+        this.printLaunchPrebrief();
 
         while (true) {
             const chain = this.getActiveChain();
@@ -352,6 +433,8 @@ class DelimitChatREPL {
                             console.log(chalk.yellow(`  ⚠ Switching to ${chalk.bold(nextModel.id)} (context save unavailable).`));
                         }
                     }
+                    // Fable doc-33: re-brief between quota migrations.
+                    this.printLaunchPrebrief();
                 } catch (e) {
                     console.log(chalk.gray('  Exiting Delimit.\n'));
                     process.exit(0);
@@ -372,6 +455,8 @@ class DelimitChatREPL {
                         console.log(chalk.yellow(`  ⚠ Switching to ${chalk.bold(nextModel.id)} (context save unavailable).`));
                     }
                 }
+                // Fable doc-33: re-brief between quota migrations.
+                this.printLaunchPrebrief();
                 // Loop continues to spawn the next model
             }
         }

--- a/scripts/test-with-config-guard.js
+++ b/scripts/test-with-config-guard.js
@@ -43,6 +43,7 @@ const TEST_FILES = [
     'tests/migration-2092-banner.test.js',
     'tests/control-browser.test.js',
     'tests/bundle-parity-guard.test.js',
+    'tests/chat-repl-prebrief.test.js',
 ];
 
 const cfgPath = resolveSharedConfigPath();

--- a/tests/chat-repl-prebrief.test.js
+++ b/tests/chat-repl-prebrief.test.js
@@ -1,0 +1,89 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+// Module under test — the Auto-Phoenix session launcher. We exercise ONLY the
+// Fable doc-33 launch pre-brief surface (getControlBrief / printLaunchPrebrief).
+// The pre-brief is a best-effort, hard-bounded, non-blocking add: it must never
+// throw to the caller and never delay/block the session launch.
+process.env.DELIMIT_WRAPPED = 'true';
+const { DelimitChatREPL } = require('../lib/chat-repl');
+
+// Capture console.log output for a single call.
+function capture(fn) {
+    const orig = console.log;
+    const lines = [];
+    console.log = (...args) => { lines.push(args.join(' ')); };
+    try {
+        fn();
+    } finally {
+        console.log = orig;
+    }
+    return lines.join('\n');
+}
+
+describe('chat launch pre-brief (Fable doc-33)', () => {
+    let repl;
+    beforeEach(() => { repl = new DelimitChatREPL(); });
+
+    it('renders the one-line brief with counts when the backend returns data', () => {
+        repl.getControlBrief = () => ({ approvals: 39, agents: 25, p0s: 251 });
+        const out = capture(() => repl.printLaunchPrebrief());
+        assert.match(out, /39 approvals waiting/);
+        assert.match(out, /25 agents running/);
+        assert.match(out, /251 P0s open/);
+        // approvals > 0 => surface the actionable hint at `delimit control`.
+        assert.match(out, /delimit control/);
+    });
+
+    it('pluralizes correctly (singular at 1, plural otherwise, including 0)', () => {
+        repl.getControlBrief = () => ({ approvals: 1, agents: 1, p0s: 1 });
+        const one = capture(() => repl.printLaunchPrebrief());
+        assert.match(one, /1 approval waiting/);
+        assert.match(one, /1 agent running/);
+        assert.match(one, /1 P0 open/);
+
+        repl.getControlBrief = () => ({ approvals: 0, agents: 0, p0s: 0 });
+        const zero = capture(() => repl.printLaunchPrebrief());
+        assert.match(zero, /0 approvals waiting/);
+        assert.match(zero, /0 agents running/);
+        assert.match(zero, /0 P0s open/);
+        // No approvals => no triage hint.
+        assert.doesNotMatch(zero, /delimit control/);
+    });
+
+    it('prints NOTHING when the backend is unreachable (getControlBrief -> null)', () => {
+        repl.getControlBrief = () => null;
+        const out = capture(() => repl.printLaunchPrebrief());
+        assert.strictEqual(out, '');
+    });
+
+    it('degrades silently and never throws when the backend call throws', () => {
+        repl.getControlBrief = () => { throw new Error('backend boom'); };
+        let out;
+        assert.doesNotThrow(() => { out = capture(() => repl.printLaunchPrebrief()); });
+        assert.strictEqual(out, '');
+    });
+
+    it('coerces non-numeric/partial payloads to 0 rather than NaN or a throw', () => {
+        repl.getControlBrief = () => ({ approvals: 'x', agents: undefined });
+        const out = capture(() => repl.printLaunchPrebrief());
+        assert.doesNotMatch(out, /NaN/);
+        assert.match(out, /0 approvals waiting/);
+        assert.match(out, /0 agents running/);
+        assert.match(out, /0 P0s open/);
+    });
+
+    it('getControlBrief never throws and returns null or a numeric-count object', () => {
+        // Runs against the real candidate resolution. Whatever the environment,
+        // the contract is: return null OR an object; never throw.
+        let brief;
+        assert.doesNotThrow(() => { brief = repl.getControlBrief(); });
+        if (brief !== null) {
+            assert.strictEqual(typeof brief, 'object');
+            // Keys, when present, must be JSON-numbers (the python side emits ints).
+            for (const k of ['approvals', 'agents', 'p0s']) {
+                if (k in brief) assert.strictEqual(typeof brief[k], 'number');
+            }
+        }
+    });
+});


### PR DESCRIPTION
## What & why (Fable doc-33)

`delimit chat` is a **governed session launcher** (Auto-Phoenix: quota fallback + soul revive), not a chat surface — and it launched **blind**. Per Fable doc-33 (`33_FABLE_CONTROL_PLANE_TUI.md` §3), this is the single **in-bounds** control-surface fix (DL-3 internal-OS, distribution-first-freeze compatible): surface the org's state at session entry + make the naming honest. No new TUI, no new tool, no new dep.

## Changes

**Launch pre-brief** (`lib/chat-repl.js`, additive):
- Prints one line at session start and between quota migrations:
  `⎿ N approvals waiting · M agents running · P0s open`, plus a `delimit control` triage hint when approvals > 0. Fixes the "control had 39 items waiting, unseen at entry" gap.
- Sourced through the read-only `control_plane` helpers (present in **both** the bundle and the installed `~/.delimit/server`) + the same raw stores the corp dashboard reads, so counts are **honest**: approvals = pending founder directives (dedup-by-subject), agents = **dispatched agent-queue tasks** (not ledger ops), p0s = **open P0 central-ledger** items.
- **HARD non-blocking:** python probe capped at **1.5s** and fully wrapped in try/catch. On any failure/timeout/empty it prints nothing and the session launches normally. No network call, no new dependency.
- Quota / models.json / shim-spawn / soul / revive logic **untouched** — purely additive.

**Honest naming** (`bin/delimit-cli.js`):
- `chat` description → "Governed session launcher: quota fallback + soul revive across models (Auto-Phoenix)". **Behavior unchanged.**
- Added `phoenix` as an additional alias.

## ⚠️ Naming decision for the founder

The directive requested `session` as the alias. **A distinct `session` command already exists** (native session-shell `runInteractiveSession`, with `--build/--inspect/--all`). Commander **throws at registration** on a duplicate name — aliasing `chat`→`session` would crash the entire CLI, and repointing bare `session` would change its default behavior (both are never-break-installs violations). So I used `phoenix` (the launcher's own internal name) and left the existing `session` command fully intact. If you want the launcher under `session`, that requires a separate decision to retire/repoint the legacy session-shell command.

## Tests
- `tests/chat-repl-prebrief.test.js` — 6 cases: renders-with-counts, pluralization (incl. 0/1), null→silent, throw→silent, NaN-coercion, contract (never-throws / null-or-numeric).
- Registered in `scripts/test-with-config-guard.js`. **Full suite: 323 pass / 0 fail** (was 317 + 6).
- Degradation proven empirically: slow backend killed at ~1.5s→null→silent; import failure→null→silent.

Do **not** merge — user-facing repo; founder hand-merge or deliberation-as-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)