### PR TITLE
feat(chat): add `delimit chat --model <id>` per-launch model selector

### DIFF
--- a/bin/delimit-cli.js
+++ b/bin/delimit-cli.js
@@ -7290,6 +7290,7 @@ program
     .alias('phoenix')
     .description('Governed session launcher: quota fallback + soul revive across models (Auto-Phoenix). Alias: phoenix')
     .option('--api-fallback', 'Enable API fallback to continue using paid tokens')
+    .option('--model <id>', 'Launch a specific model first (e.g. codex, claude, antigravity); the rest of the default chain stays as Auto-Phoenix fallback')
     .action((options) => {
         const { DelimitChatREPL } = require('../lib/chat-repl');
         const repl = new DelimitChatREPL(options);

--- a/lib/chat-repl.js
+++ b/lib/chat-repl.js
@@ -16,6 +16,9 @@ class DelimitChatREPL {
         this.modelsConfig = this.loadModels();
         this.routesConfig = this.loadRoutes();
         this.agentName = 'orchestrator'; // Default agent
+        // --model <id>: launch a specific model first this session, leaving the
+        // default fallback chain (and models.json) untouched. null = normal chain.
+        this.launchModel = options.model || null;
     }
 
     loadModels() {
@@ -41,17 +44,28 @@ class DelimitChatREPL {
     }
 
     getActiveChain() {
-        const chain = this.modelsConfig.fallbacks?.['default'] || [];
+        let chain = this.modelsConfig.fallbacks?.['default'] || [];
+        // --model <id>: put the requested model first; the rest of the default
+        // chain stays as Auto-Phoenix fallback. Unknown id → warn once, ignore.
+        if (this.launchModel) {
+            if (this.modelsConfig[this.launchModel]) {
+                chain = [this.launchModel, ...chain.filter(p => p !== this.launchModel)];
+            } else {
+                console.log(chalk.yellow(`  ⚠ --model '${this.launchModel}' is not defined in models.json; using default chain.`));
+                this.launchModel = null;
+            }
+        }
         const activeModels = [];
-        
+
         for (const provider of chain) {
             if (this.failedModels.has(provider)) continue;
             const p = this.modelsConfig[provider];
             if (!p) continue;
-            
+
             if (p.auth_mode === 'chat_login' || p.auth_mode === 'adc') {
                 activeModels.push({ id: provider, type: 'subscription' });
-            } else if (p.api_key && this.apiFallbackEnabled) {
+            } else if (p.api_key && (this.apiFallbackEnabled || provider === this.launchModel)) {
+                // An explicitly-requested api-only model is honored even without --api-fallback.
                 activeModels.push({ id: provider, type: 'api' });
             }
         }

--- a/tests/chat-repl-model-flag.test.js
+++ b/tests/chat-repl-model-flag.test.js
@@ -1,0 +1,67 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+// Module under test — the Auto-Phoenix launcher's `--model <id>` per-launch
+// override (getActiveChain). The flag must reorder the chain WITHOUT mutating
+// models.json, must leave the default chain intact when absent, and must
+// degrade gracefully (warn once, fall back) on an unknown id.
+process.env.DELIMIT_WRAPPED = 'true';
+const { DelimitChatREPL } = require('../lib/chat-repl');
+
+// A controlled models fixture so the test does not depend on ~/.delimit/models.json.
+const FIXTURE = {
+    claude: { auth_mode: 'chat_login' },
+    codex: { auth_mode: 'chat_login' },
+    antigravity: { auth_mode: 'chat_login' },
+    grok: { api_key: 'x' }, // api-only, no chat_login
+    fallbacks: { default: ['claude', 'codex', 'antigravity'] },
+};
+
+function replWith(options) {
+    const r = new DelimitChatREPL(options);
+    r.modelsConfig = JSON.parse(JSON.stringify(FIXTURE));
+    return r;
+}
+
+function silence(fn) {
+    const orig = console.log;
+    console.log = () => {};
+    try { return fn(); } finally { console.log = orig; }
+}
+
+describe('chat --model <id> per-launch override', () => {
+    it('uses the default chain unchanged when --model is absent', () => {
+        const ids = replWith({}).getActiveChain().map(m => m.id);
+        assert.deepStrictEqual(ids, ['claude', 'codex', 'antigravity']);
+    });
+
+    it('launches the requested model first, keeping the rest as fallback', () => {
+        const ids = replWith({ model: 'codex' }).getActiveChain().map(m => m.id);
+        assert.deepStrictEqual(ids, ['codex', 'claude', 'antigravity']);
+    });
+
+    it('does not duplicate the model if it is already in the chain', () => {
+        const ids = replWith({ model: 'antigravity' }).getActiveChain().map(m => m.id);
+        assert.deepStrictEqual(ids, ['antigravity', 'claude', 'codex']);
+    });
+
+    it('honors an explicitly-requested api-only model even without --api-fallback', () => {
+        // grok is api-only and not in the default chain; --model must surface it.
+        const ids = replWith({ model: 'grok' }).getActiveChain().map(m => m.id);
+        assert.strictEqual(ids[0], 'grok');
+    });
+
+    it('warns once and falls back to the default chain on an unknown id', () => {
+        const r = replWith({ model: 'nope' });
+        const ids = silence(() => r.getActiveChain().map(m => m.id));
+        assert.deepStrictEqual(ids, ['claude', 'codex', 'antigravity']);
+        // launchModel is cleared after the warning so it never repeats.
+        assert.strictEqual(r.launchModel, null);
+    });
+
+    it('never mutates fallbacks.default in the loaded config', () => {
+        const r = replWith({ model: 'codex' });
+        silence(() => r.getActiveChain());
+        assert.deepStrictEqual(r.modelsConfig.fallbacks.default, ['claude', 'codex', 'antigravity']);
+    });
+});


### PR DESCRIPTION
## What
Adds a purely additive `--model <id>` flag to `delimit chat` (alias `delimit phoenix`) so you can launch a specific model first for a single session — e.g. `delimit chat --model codex` — without hand-editing `~/.delimit/models.json`.

## Why
The Auto-Phoenix launcher always started `fallbacks.default[0]`. The only way to launch a non-default model (Codex) was to permanently reorder the default chain in `models.json`. This gives per-launch selection while leaving the durable config alone.

## Behavior
- `delimit chat` (no flag) → **byte-identical** to before: default chain `claude → codex → antigravity`.
- `delimit chat --model codex` → chain becomes `codex → claude → antigravity` (requested model first, **rest stays as Auto-Phoenix fallback**).
- Already-in-chain model → deduped (no double entry).
- Unknown id → warns once, falls back to the default chain (never crashes).
- An explicitly-requested api-only model is honored even without `--api-fallback`.
- `models.json` is **never mutated**.

## Never-break-installs
Adds one option; removes/renames nothing. No storage-format, tool-signature, or default-behavior change.

## Tests
6 new hermetic tests (fixture-injected config) + existing pre-brief tests still green: `12 pass / 0 fail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)