### PR TITLE
chore(bundle): classify brand_notes.py INTERNAL (guard catch #1)

### DIFF
--- a/bundle-internal-exclude.txt
+++ b/bundle-internal-exclude.txt
@@ -15,9 +15,9 @@
 # list is the audit record of *why* each non-shipped file is excluded; see
 # bundle-classification.md for the per-file reason.
 # ============================================================================
-
 gateway/ai/board_pack.py
 gateway/ai/board_report.py
+gateway/ai/brand_notes.py
 gateway/ai/content_engine.py
 gateway/ai/content_grounding/__init__.py
 gateway/ai/content_grounding/build.py


### PR DESCRIPTION
One-line classification. The new fail-closed guard's first real catch: the LED-1880 brand content engine (merged to the gateway after the allowlist was written) was unclassified and correctly BLOCKED the Gate-5 publish dry-run. Internal marketing automation → INTERNAL-EXCLUDE like all social_* modules. Guard passes locally after classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)