### PR TITLE
fix(release): never commit proprietary gateway source to the public repo (LED-1900)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -120,6 +120,26 @@ echo "[5/5] Committing and tagging..."
 # Stage synced gateway files too (sync-gateway may have updated them)
 git add package.json package-lock.json server.json gateway/
 
+# LED-1900: sync-gateway copies proprietary/internal SOURCE (e.g.
+# license_core.py, which ships only as a compiled .so) into the tree. The
+# bundle guards gate the npm PACK, not the git COMMIT — so `git add gateway/`
+# would commit that source to the PUBLIC repo. Prune every bundle-internal
+# path from the index + working tree, then HARD-ASSERT none remain staged.
+if [ -f bundle-internal-exclude.txt ]; then
+    while IFS= read -r _excl; do
+        case "$_excl" in ''|\#*) continue ;; esac
+        git reset -q -- "$_excl" 2>/dev/null || true
+        rm -f "$_excl" 2>/dev/null || true
+    done < bundle-internal-exclude.txt
+    _leaked=$(git diff --cached --name-only | grep -Ff <(grep -vE '^\s*#|^\s*$' bundle-internal-exclude.txt) || true)
+    if [ -n "$_leaked" ]; then
+        echo "ERROR: internal/proprietary file(s) staged for the public release commit:" >&2
+        echo "$_leaked" >&2
+        echo "Refusing to commit. Fix the prune step before releasing." >&2
+        exit 1
+    fi
+fi
+
 # Use a release branch to avoid main branch protection
 RELEASE_BRANCH="release/v$VERSION"
 git checkout -b "$RELEASE_BRANCH"


### PR DESCRIPTION
**Incident + fix.** The founder-authorized 'publish 4.16.0' ran release.sh, which briefly pushed a release branch to the PUBLIC repo containing gateway/ai/license_core.py (proprietary; ships only as .so). Caught pre-tag — NOTHING published (no tag, npm still 4.14.2), leaked branch deleted within minutes.

Root cause: release.sh's `git add gateway/` stages everything sync-gateway regenerates, including proprietary source. The bundle guards gate the npm PACK, not the git COMMIT.

Fix: prune every bundle-internal-exclude.txt path from the index + working tree after staging, then a fail-closed hard-assert that refuses to commit if any internal file remains staged. Verified end-to-end: license_core.py pruned, assert clean, allowlisted public files preserved.

Blocks re-running the 4.16.0 release until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)