### PR TITLE
release: v4.16.0

### DIFF
--- a/gateway/ai/server.py
+++ b/gateway/ai/server.py
@@ -646,7 +646,45 @@ mcp.description = (
     "Use delimit_scan on new projects. Track all work via the ledger."
 )
 
-VERSION = "3.2.1"
+# Version truth (LED-1889): the served version is DERIVED, never hand-edited.
+# Canonical source = the delimit-cli package manifest this server ships inside.
+# Resolution order (first hit wins), walking up from this file:
+#   1. a `VERSION` marker file (written into the bundle / installed
+#      ~/.delimit/server tree at publish/sync time)
+#   2. a `package.json` whose name is `delimit-cli` (npm bundle layout:
+#      gateway/ai/server.py ← ../../package.json)
+#   3. the pinned fallback below (last resort so the delimit_version return
+#      schema never changes shape — never-break-installs).
+_VERSION_FALLBACK = "4.15.0"
+
+
+def _resolve_version(start_path: Optional[str] = None) -> str:
+    """Resolve the shipped package version from the bundle's own manifest.
+
+    Read-only; any I/O or parse failure falls back to _VERSION_FALLBACK.
+    """
+    try:
+        here = Path(start_path or __file__).resolve()
+        for parent in list(here.parents)[:4]:
+            marker = parent / "VERSION"
+            if marker.is_file():
+                candidate = marker.read_text(encoding="utf-8").strip()
+                if candidate:
+                    return candidate
+            pkg = parent / "package.json"
+            if pkg.is_file():
+                try:
+                    data = json.loads(pkg.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    continue
+                if data.get("name") == "delimit-cli" and data.get("version"):
+                    return str(data["version"])
+    except Exception:
+        pass
+    return _VERSION_FALLBACK
+
+
+VERSION = _resolve_version()
 
 # LED-044 + Consensus 118/119/120: Tool visibility tiers.
 # Tier cascade: SHOW_EXPERIMENTAL > SHOW_INTERNAL > SHOW_OPS > public (always visible).
@@ -2459,7 +2497,7 @@ def delimit_os_plan(
 
 @mcp.tool()
 def delimit_os_status() -> Dict[str, Any]:
-    """Report Delimit OS overall status (plans, tasks, tokens) (Pro).
+    """Report overall Delimit platform status (plans, tasks, tokens) (Pro).
 
     When to use: at session start or in a status dashboard, to read
     aggregate OS-level counts and active plan IDs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "delimit-cli",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "delimit-cli",
-      "version": "4.15.0",
+      "version": "4.16.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "delimit-cli",
   "mcpName": "io.github.delimit-ai/delimit-mcp-server",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "The merge gate for AI-written code, with signed, replayable attestation. Works with Claude Code, Codex, Cursor, and Gemini CLI.",
   "main": "index.js",
   "files": [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/delimit-ai/delimit-mcp-server",
     "source": "github"
   },
-  "version": "4.15.0",
+  "version": "4.16.0",
   "websiteUrl": "https://delimit.ai",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "delimit-cli",
-      "version": "4.15.0",
+      "version": "4.16.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Founder-authorized release (publish 4.16.0 + publish.yml re-confirm). Release commit verified leak-free: LED-1900 prune+assert active (4 files: version bump, lockfile, server.json sync, gateway/VERSION marker — no proprietary source). Publishes via the tag-triggered publish.yml with both bundle guards.