### PR TITLE
fix(chat): TTL-expiring Phoenix failover + deterministic quota probe (LED-3432, LED-3433)

### DIFF
--- a/lib/chat-repl.js
+++ b/lib/chat-repl.js
@@ -7,12 +7,82 @@ const { spawnSync, execSync } = require('child_process');
 // Banner version is read from package.json so it never goes stale per release.
 const PKG_VERSION = (() => { try { return require('../package.json').version; } catch (e) { return ''; } })();
 
+// LED-3432: how long a failed-over model stays excluded from the Auto-Phoenix
+// chain before it becomes eligible again (the per-launch quota probe then
+// re-verifies actual health before the session is handed over). Previously a
+// failure was terminal for the whole process lifetime, so long-running
+// sessions never returned to the primary model after its quota window reset.
+const DEFAULT_PHOENIX_FAIL_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+// Defensive env-override parse: any non-finite / non-positive / garbage value
+// falls back to the default rather than throwing or disabling expiry.
+function resolvePhoenixFailTtlMs(env = process.env) {
+    const raw = env && env.DELIMIT_PHOENIX_FAIL_TTL_MS;
+    if (raw === undefined || raw === null || String(raw).trim() === '') {
+        return DEFAULT_PHOENIX_FAIL_TTL_MS;
+    }
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) return DEFAULT_PHOENIX_FAIL_TTL_MS;
+    return Math.floor(n);
+}
+
+// LED-3432: drop-in replacement for the old `new Set()` failed-model tracker.
+// Exposes the SAME interface points the launcher already uses (`add`, `has`,
+// plus `delete`/`clear` for Set parity) but timestamps each failure so it
+// expires after a TTL. Within the TTL window behavior is identical to the Set.
+class FailedModelRegistry {
+    constructor(options = {}) {
+        this.ttlMs = (typeof options.ttlMs === 'number' && Number.isFinite(options.ttlMs) && options.ttlMs > 0)
+            ? options.ttlMs
+            : resolvePhoenixFailTtlMs();
+        this._now = typeof options.now === 'function' ? options.now : Date.now;
+        this._failures = new Map(); // model id -> failedAtEpochMs
+    }
+
+    add(modelId) {
+        this._failures.set(modelId, this._now());
+        return this;
+    }
+
+    has(modelId) {
+        const failedAt = this._failures.get(modelId);
+        if (failedAt === undefined) return false;
+        if (this._now() - failedAt >= this.ttlMs) {
+            // Expired: the model is eligible again; the per-launch probe
+            // re-verifies real health before any session is handed to it.
+            this._failures.delete(modelId);
+            return false;
+        }
+        return true;
+    }
+
+    delete(modelId) {
+        return this._failures.delete(modelId);
+    }
+
+    clear() {
+        this._failures.clear();
+    }
+
+    get size() {
+        // Count only non-expired failures (Set-parity semantics).
+        let n = 0;
+        for (const key of Array.from(this._failures.keys())) {
+            if (this.has(key)) n += 1;
+        }
+        return n;
+    }
+}
+
 class DelimitChatREPL {
     constructor(options = {}) {
-        this.apiFallbackEnabled = options.apiFallback !== undefined ? 
-            !!options.apiFallback : 
+        this.apiFallbackEnabled = options.apiFallback !== undefined ?
+            !!options.apiFallback :
             (process.env.DELIMIT_API_FALLBACK === 'true' || false);
-        this.failedModels = new Set();
+        // LED-3432: TTL-expiring failure tracker (same add/has interface the
+        // rest of the launcher already uses). `failTtlMs`/`now` options are
+        // additive and internal/testing-only.
+        this.failedModels = new FailedModelRegistry({ ttlMs: options.failTtlMs, now: options.now });
         this.modelsConfig = this.loadModels();
         this.routesConfig = this.loadRoutes();
         this.agentName = 'orchestrator'; // Default agent
@@ -194,6 +264,138 @@ class DelimitChatREPL {
         } catch (e) { /* pre-brief is best-effort; never block the session */ }
     }
 
+    // LED-3433: which models get the pre-launch quota/health probe. Codex is
+    // now probed too (it used to be trusted blind before the session handoff).
+    shouldProbe(modelId) {
+        return modelId === 'claude'
+            || modelId === 'codex'
+            || modelId === 'gemini'
+            || modelId === 'gemini_consumer'
+            || modelId === 'antigravity';
+    }
+
+    // Probe environment mirrors the run environment (same auth-mode-sensitive
+    // env stripping the interactive launch performs). Codex needs no strips.
+    buildProbeEnv(modelId) {
+        const probeEnv = { ...process.env, DELIMIT_QUIET: 'true' };
+        const p = this.modelsConfig[modelId];
+        if (modelId === 'claude') {
+            if (p && p.auth_mode === 'chat_login') {
+                delete probeEnv.ANTHROPIC_API_KEY;
+            }
+        } else if (modelId === 'gemini' || modelId === 'gemini_consumer' || modelId === 'antigravity') {
+            if (!p || p.auth_mode === 'chat_login') {
+                delete probeEnv.GOOGLE_CLOUD_PROJECT;
+                delete probeEnv.GEMINI_USER_GCP_PROJECT;
+                delete probeEnv.GEMINI_CLI_USE_COMPUTE_ADC;
+                delete probeEnv.GOOGLE_APPLICATION_CREDENTIALS;
+            }
+        }
+        return probeEnv;
+    }
+
+    // Spawn layer for the probe — a seam so tests can mock it (no live CLIs).
+    // Spawns the shim silently with -p "space". Cold-start + MCP load + API
+    // round-trip can exceed a few seconds, so a timeout means SLOW, not out of
+    // quota. The shim is a /bin/sh wrapper that exits 143 (128+SIGTERM) when
+    // our timeout kills it — a timeout shows up as BOTH error=ETIMEDOUT AND
+    // status=143; both are treated as healthy-but-slow.
+    _runProbe(shimPath, probeEnv) {
+        return spawnSync(shimPath, ['-p', 'space'], { env: probeEnv, timeout: 12000 });
+    }
+
+    // Retry backoff seam (overridable in tests so nothing sleeps for real).
+    _probeBackoff(ms) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+    }
+
+    // LED-3433: DETERMINISTIC probe verdict. Keyed off the child exit code +
+    // stderr signatures ONLY — the free-form stdout reply is NEVER consulted.
+    // A model that merely *talks about* rate limits in its reply must not be
+    // classified quota-dead (the old grep of stdout+stderr false-positived on
+    // exactly that). Verdicts:
+    //   slow            — timeout/SIGTERM/143: reachable but cold; healthy
+    //   healthy         — exit 0, regardless of any words in the reply
+    //   quota_exhausted — nonzero exit + sticky plan-cap signature on stderr
+    //   transient       — nonzero exit + transient 429/503 signature on stderr
+    //   auth_error      — nonzero exit + auth/login signature on stderr
+    //   probe_error     — nonzero exit / spawn error with no known signature
+    classifyProbeResult(r) {
+        const timedOut = (r.error && r.error.code === 'ETIMEDOUT')
+            || r.signal === 'SIGTERM'
+            || r.status === 143;
+        if (timedOut) return { verdict: 'slow' };
+        if (r.status === 0) return { verdict: 'healthy' };
+        const stderr = (r.stderr || '').toString().toLowerCase();
+        // A GENUINE subscription usage-cap exhaustion (the 5-hour rolling plan
+        // cap or a hard quota). This is the ONLY signal that should fall the
+        // model over as quota-dead. Deliberately does NOT include bare
+        // "rate limit"/429/"exceeded", which a transient overload also emits.
+        const QUOTA_EXHAUSTED = /usage limit|limit reached|reached your .{0,20}\blimit\b|spend limit|plan limit|monthly limit|out of (?:credits|tokens)|\bquota\b/;
+        // A TRANSIENT, self-healing rate-limit / overload (HTTP 429/503).
+        // Retrying shortly usually clears it — never blame quota for it.
+        const TRANSIENT_RATE_LIMIT = /\b429\b|\b503\b|rate.?limit|rate_limit|overloaded|service unavailable|temporarily unavailable|please try again|try again later/;
+        // Known auth failures — the model is unusable until re-login, so fall
+        // over to the next chain model (same failover as quota, clearer log).
+        const AUTH_ERROR = /not logged in|login required|please (?:log ?in|sign ?in)|authentication|unauthorized|invalid api key|\b401\b|credentials? (?:not found|expired|invalid)/;
+        if (QUOTA_EXHAUSTED.test(stderr) && !TRANSIENT_RATE_LIMIT.test(stderr)) {
+            return { verdict: 'quota_exhausted' };
+        }
+        if (TRANSIENT_RATE_LIMIT.test(stderr)) return { verdict: 'transient' };
+        if (AUTH_ERROR.test(stderr)) return { verdict: 'auth_error' };
+        if (r.error || (r.status !== null && r.status !== 0)) return { verdict: 'probe_error' };
+        return { verdict: 'healthy' };
+    }
+
+    // Probe model quota/health before entering the interactive session.
+    // Returns true (healthy → hand the session over) or false (fail over to
+    // the next chain model). Fail-open on non-quota probe errors is preserved:
+    // we log and continue down the chain exactly as before.
+    probeModelHealth(activeModel, shimPath) {
+        process.stdout.write(`  Probing ${chalk.bold(activeModel.id)} quota... `);
+        const probeEnv = this.buildProbeEnv(activeModel.id);
+        let c = this.classifyProbeResult(this._runProbe(shimPath, probeEnv));
+
+        // If the first probe shows ONLY a transient rate-limit (no genuine cap
+        // signal), back off briefly and re-probe once. A real plan-cap is
+        // sticky and survives the retry; a transient 429 usually clears.
+        if (c.verdict === 'transient') {
+            console.log(chalk.yellow('rate-limited — retrying once'));
+            this._probeBackoff(3000);
+            process.stdout.write(`  Re-probing ${chalk.bold(activeModel.id)} quota... `);
+            c = this.classifyProbeResult(this._runProbe(shimPath, probeEnv));
+        }
+
+        switch (c.verdict) {
+            case 'slow':
+                // Reachable but slow (cold start) — NOT a quota signal. Proceed.
+                console.log(chalk.yellow('slow — proceeding'));
+                return true;
+            case 'healthy':
+                console.log(chalk.green('verified'));
+                return true;
+            case 'transient':
+                // Still transient after the retry — the plan is NOT exhausted,
+                // the API is briefly busy. Proceed rather than falsely falling
+                // back; if it's truly down the interactive launch fails and the
+                // existing crash handler migrates.
+                console.log(chalk.yellow('transient rate-limit — proceeding (not a quota cap)'));
+                return true;
+            case 'quota_exhausted':
+                // Sticky plan-cap exhaustion — fall over to the next model.
+                console.log(chalk.red('failed (out of quota/limit)'));
+                return false;
+            case 'auth_error':
+                console.log(chalk.red('failed (auth error)'));
+                return false;
+            default:
+                // Some other error — don't falsely blame quota; log and let the
+                // chain continue to the next model, as before.
+                console.log(chalk.red('failed (probe error)'));
+                return false;
+        }
+    }
+
     start() {
                 console.log(chalk.magenta.bold(`
   ██████╗ ███████╗██╗     ██╗███╗   ███╗██╗████████╗
@@ -258,89 +460,15 @@ class DelimitChatREPL {
                 continue;
             }
 
-            // Probe model quota/health before entering interactive session
+            // Probe model quota/health before entering interactive session.
+            // LED-3433: deterministic verdict (exit code + stderr signatures,
+            // never the stdout reply text); codex is probed too, not trusted
+            // blind. See probeModelHealth/classifyProbeResult above.
             let isHealthy = true;
-            if (activeModel.id === 'claude' || activeModel.id === 'gemini' || activeModel.id === 'gemini_consumer' || activeModel.id === 'antigravity') {
-                process.stdout.write(`  Probing ${chalk.bold(activeModel.id)} quota... `);
-                
-                // Configure environment for the probe (identical to the run environment)
-                const probeEnv = { ...process.env, DELIMIT_QUIET: 'true' };
-                const p = this.modelsConfig[activeModel.id];
-                if (activeModel.id === 'claude') {
-                    if (p && p.auth_mode === 'chat_login') {
-                        delete probeEnv.ANTHROPIC_API_KEY;
-                    }
-                } else if (activeModel.id === 'gemini' || activeModel.id === 'gemini_consumer' || activeModel.id === 'antigravity') {
-                    if (!p || p.auth_mode === 'chat_login') {
-                        delete probeEnv.GOOGLE_CLOUD_PROJECT;
-                        delete probeEnv.GEMINI_USER_GCP_PROJECT;
-                        delete probeEnv.GEMINI_CLI_USE_COMPUTE_ADC;
-                        delete probeEnv.GOOGLE_APPLICATION_CREDENTIALS;
-                    }
-                }
-                
-                // A GENUINE subscription usage-cap exhaustion (the 5-hour rolling
-                // plan cap or a hard quota). This is the ONLY signal that should
-                // fall the model over to the next in the chain. Deliberately does
-                // NOT include bare "rate limit"/429/"exceeded", which a transient
-                // overload also emits and which was the false-quota source.
-                const QUOTA_EXHAUSTED = /usage limit|limit reached|reached your .{0,20}\blimit\b|spend limit|plan limit|monthly limit|out of (?:credits|tokens)|\bquota\b/;
-                // A TRANSIENT, self-healing rate-limit / overload (HTTP 429/503).
-                // Retrying shortly usually clears it, so it must never be blamed
-                // on quota — proceed (or retry) instead of falling back.
-                const TRANSIENT_RATE_LIMIT = /\b429\b|\b503\b|rate.?limit|rate_limit|overloaded|service unavailable|temporarily unavailable|please try again|try again later/;
-
-                // Spawn the shim silently with -p "space". Cold-start + MCP load
-                // + API round-trip can exceed a few seconds, so a timeout means
-                // SLOW, not out of quota. The shim is a /bin/sh wrapper that exits
-                // 143 (128+SIGTERM) when our timeout kills it — so a timeout shows
-                // up as BOTH error=ETIMEDOUT AND status=143; treat both as healthy.
-                const runProbe = () => {
-                    const r = spawnSync(shimPath, ['-p', 'space'], { env: probeEnv, timeout: 12000 });
-                    const timedOut = (r.error && r.error.code === 'ETIMEDOUT')
-                        || r.signal === 'SIGTERM'
-                        || r.status === 143;
-                    const out = ((r.stdout || '') + (r.stderr || '')).toString().toLowerCase();
-                    return { r, timedOut, out };
-                };
-
-                let { r: probeResult, timedOut: killedByTimeout, out: probeOut } = runProbe();
-
-                // If the first probe shows ONLY a transient rate-limit (no genuine
-                // cap signal), back off briefly and re-probe once. A real plan-cap
-                // is sticky and survives the retry; a transient 429 usually clears.
-                if (!killedByTimeout && TRANSIENT_RATE_LIMIT.test(probeOut) && !QUOTA_EXHAUSTED.test(probeOut)) {
-                    console.log(chalk.yellow('rate-limited — retrying once'));
-                    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 3000);
-                    process.stdout.write(`  Re-probing ${chalk.bold(activeModel.id)} quota... `);
-                    ({ r: probeResult, timedOut: killedByTimeout, out: probeOut } = runProbe());
-                }
-
-                const quotaExhausted = QUOTA_EXHAUSTED.test(probeOut);
-                const transientRateLimit = TRANSIENT_RATE_LIMIT.test(probeOut);
-
-                if (killedByTimeout) {
-                    // Reachable but slow (cold start) — NOT a quota signal. Proceed.
-                    console.log(chalk.yellow('slow — proceeding'));
-                } else if (quotaExhausted && !transientRateLimit) {
-                    // Sticky plan-cap exhaustion — fall over to the next model.
-                    console.log(chalk.red('failed (out of quota/limit)'));
-                    isHealthy = false;
-                } else if (transientRateLimit) {
-                    // Still transient after the retry — the plan is NOT exhausted,
-                    // the API is briefly busy. Proceed rather than falsely falling
-                    // back; if it's truly down the interactive launch fails and the
-                    // existing crash handler migrates.
-                    console.log(chalk.yellow('transient rate-limit — proceeding (not a quota cap)'));
-                } else if (probeResult.error || (probeResult.status !== null && probeResult.status !== 0)) {
-                    // Some other error — don't falsely blame quota.
-                    console.log(chalk.red('failed (probe error)'));
-                    isHealthy = false;
-                } else {
-                    console.log(chalk.green('verified'));
-                }
+            if (this.shouldProbe(activeModel.id)) {
+                isHealthy = this.probeModelHealth(activeModel, shimPath);
             }
-            
+
             if (!isHealthy) {
                 this.failedModels.add(activeModel.id);
                 continue;
@@ -477,4 +605,11 @@ class DelimitChatREPL {
     }
 }
 
-module.exports = { DelimitChatREPL };
+// FailedModelRegistry / TTL helpers are exported additively (LED-3432) for
+// tests and tooling; DelimitChatREPL remains the primary public surface.
+module.exports = {
+    DelimitChatREPL,
+    FailedModelRegistry,
+    resolvePhoenixFailTtlMs,
+    DEFAULT_PHOENIX_FAIL_TTL_MS,
+};

--- a/tests/chat-repl-phoenix-ttl-probe.test.js
+++ b/tests/chat-repl-phoenix-ttl-probe.test.js
@@ -1,0 +1,181 @@
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+// Module under test — LED-3432 (TTL-expiring failed-model tracker) and
+// LED-3433 (deterministic quota probe: exit code + stderr signatures only,
+// never the stdout reply text; codex probed too).
+//
+// Hermetic per tests/chat-repl-model-flag.test.js conventions: fixture-injected
+// modelsConfig, no live CLIs — the spawn/probe layer (_runProbe) is mocked.
+process.env.DELIMIT_WRAPPED = 'true';
+const {
+    DelimitChatREPL,
+    FailedModelRegistry,
+    resolvePhoenixFailTtlMs,
+    DEFAULT_PHOENIX_FAIL_TTL_MS,
+} = require('../lib/chat-repl');
+
+// A controlled models fixture so tests do not depend on ~/.delimit/models.json.
+const FIXTURE = {
+    claude: { auth_mode: 'chat_login' },
+    codex: { auth_mode: 'chat_login' },
+    antigravity: { auth_mode: 'chat_login' },
+    fallbacks: { default: ['claude', 'codex', 'antigravity'] },
+};
+
+function replWith(options) {
+    const r = new DelimitChatREPL(options || {});
+    r.modelsConfig = JSON.parse(JSON.stringify(FIXTURE));
+    return r;
+}
+
+// Silence console.log AND process.stdout.write (the probe writes both).
+function silence(fn) {
+    const origLog = console.log;
+    const origWrite = process.stdout.write;
+    console.log = () => {};
+    process.stdout.write = () => true;
+    try { return fn(); } finally {
+        console.log = origLog;
+        process.stdout.write = origWrite;
+    }
+}
+
+// A spawnSync-shaped probe result.
+function probeResult(over) {
+    return { status: 0, stdout: '', stderr: '', signal: null, error: undefined, ...over };
+}
+
+describe('LED-3432 failedModels TTL expiry', () => {
+    it('excludes a failed model within the TTL and includes it again after expiry', () => {
+        let clock = 0;
+        const r = replWith({ failTtlMs: 1000, now: () => clock });
+        r.failedModels.add('claude');
+
+        // Within TTL: excluded, exactly like the old Set semantics.
+        assert.deepStrictEqual(
+            r.getActiveChain().map(m => m.id),
+            ['codex', 'antigravity'],
+        );
+        clock = 999;
+        assert.deepStrictEqual(
+            r.getActiveChain().map(m => m.id),
+            ['codex', 'antigravity'],
+        );
+
+        // At/after TTL: eligible again — the per-launch probe re-verifies
+        // real health before any session handoff (that is the re-probe).
+        clock = 1000;
+        assert.deepStrictEqual(
+            r.getActiveChain().map(m => m.id),
+            ['claude', 'codex', 'antigravity'],
+        );
+    });
+
+    it('a re-failure after expiry restarts the TTL window', () => {
+        let clock = 0;
+        const reg = new FailedModelRegistry({ ttlMs: 100, now: () => clock });
+        reg.add('claude');
+        clock = 100;
+        assert.strictEqual(reg.has('claude'), false); // expired
+        reg.add('claude'); // fails over again at t=100
+        clock = 150;
+        assert.strictEqual(reg.has('claude'), true); // new window active
+        clock = 200;
+        assert.strictEqual(reg.has('claude'), false);
+    });
+});
+
+describe('LED-3432 DELIMIT_PHOENIX_FAIL_TTL_MS env override', () => {
+    afterEach(() => { delete process.env.DELIMIT_PHOENIX_FAIL_TTL_MS; });
+
+    it('respects a valid env override', () => {
+        assert.strictEqual(resolvePhoenixFailTtlMs({ DELIMIT_PHOENIX_FAIL_TTL_MS: '5000' }), 5000);
+        process.env.DELIMIT_PHOENIX_FAIL_TTL_MS = '7500';
+        const reg = new FailedModelRegistry();
+        assert.strictEqual(reg.ttlMs, 7500);
+    });
+
+    it('falls back to the default on garbage / non-positive / empty values', () => {
+        for (const garbage of ['banana', '-5', '0', '', '   ', 'NaN', 'Infinity']) {
+            assert.strictEqual(
+                resolvePhoenixFailTtlMs({ DELIMIT_PHOENIX_FAIL_TTL_MS: garbage }),
+                DEFAULT_PHOENIX_FAIL_TTL_MS,
+                `garbage value ${JSON.stringify(garbage)} must fall back to default`,
+            );
+        }
+        assert.strictEqual(resolvePhoenixFailTtlMs({}), DEFAULT_PHOENIX_FAIL_TTL_MS);
+    });
+});
+
+describe('LED-3433 deterministic quota probe', () => {
+    it('exit 0 with a reply that merely mentions "limit"/"quota" is HEALTHY (false-positive regression)', () => {
+        const r = replWith({});
+        r._runProbe = () => probeResult({
+            status: 0,
+            stdout: 'Rate limits and quota exhaustion: you have reached your usage limit is a common 429 error...',
+        });
+        // Pure classifier: stdout is NEVER consulted on a successful exit.
+        assert.strictEqual(
+            r.classifyProbeResult(probeResult({ status: 0, stdout: 'usage limit reached; quota exceeded' })).verdict,
+            'healthy',
+        );
+        // End-to-end probe verdict.
+        const healthy = silence(() => r.probeModelHealth({ id: 'claude' }, '/fake/shim'));
+        assert.strictEqual(healthy, true);
+    });
+
+    it('nonzero exit + stderr quota signature => failover', () => {
+        const r = replWith({});
+        r._runProbe = () => probeResult({
+            status: 1,
+            stderr: 'Error: usage limit reached for your plan',
+        });
+        const healthy = silence(() => r.probeModelHealth({ id: 'claude' }, '/fake/shim'));
+        assert.strictEqual(healthy, false);
+        assert.strictEqual(
+            r.classifyProbeResult(probeResult({ status: 1, stderr: 'you have hit your plan limit' })).verdict,
+            'quota_exhausted',
+        );
+    });
+
+    it('quota words on STDOUT with nonzero exit and clean stderr never classify as quota-dead', () => {
+        const r = replWith({});
+        const c = r.classifyProbeResult(probeResult({
+            status: 1,
+            stdout: 'quota usage limit reached', // must be ignored
+            stderr: 'segmentation fault',
+        }));
+        assert.strictEqual(c.verdict, 'probe_error'); // fails over, but not blamed on quota
+    });
+
+    it('timeout (ETIMEDOUT / SIGTERM / 143) stays healthy-but-slow', () => {
+        const r = replWith({});
+        assert.strictEqual(r.classifyProbeResult(probeResult({ status: 143 })).verdict, 'slow');
+        assert.strictEqual(r.classifyProbeResult(probeResult({ status: null, signal: 'SIGTERM' })).verdict, 'slow');
+        assert.strictEqual(r.classifyProbeResult(probeResult({ status: null, error: { code: 'ETIMEDOUT' } })).verdict, 'slow');
+    });
+
+    it('transient rate-limit on stderr retries once then proceeds (fail-open)', () => {
+        const r = replWith({});
+        let calls = 0;
+        r._probeBackoff = () => {}; // no real sleep in tests
+        r._runProbe = () => { calls += 1; return probeResult({ status: 1, stderr: '429 too many requests' }); };
+        const healthy = silence(() => r.probeModelHealth({ id: 'claude' }, '/fake/shim'));
+        assert.strictEqual(calls, 2); // initial probe + one retry
+        assert.strictEqual(healthy, true); // transient is never blamed on quota
+    });
+
+    it('codex is now on the probed launch path and the probe hook is invoked for it', () => {
+        const r = replWith({});
+        // start() gates the probe on shouldProbe(activeModel.id) — codex is in.
+        assert.strictEqual(r.shouldProbe('codex'), true);
+        let probedShim = null;
+        let calls = 0;
+        r._runProbe = (shimPath) => { calls += 1; probedShim = shimPath; return probeResult({ status: 0, stdout: 'ok' }); };
+        const healthy = silence(() => r.probeModelHealth({ id: 'codex' }, '/fake/shims/codex'));
+        assert.strictEqual(calls, 1);
+        assert.strictEqual(probedShim, '/fake/shims/codex');
+        assert.strictEqual(healthy, true);
+    });
+});


### PR DESCRIPTION
Implements **LED-3432** (TTL-expiring Phoenix failover) and **LED-3433** (deterministic quota probe) in `lib/chat-repl.js` (the Auto-Phoenix session launcher).

## LED-3432 — failedModels TTL
- `this.failedModels` is now a `FailedModelRegistry` (Map of model → failedAtEpoch) exposing the **same `add`/`has`/`delete`/`clear` interface** the launcher already used with the old `Set` — all four failure sites and `getActiveChain()` are untouched at the call-site level.
- A failure expires after **30 minutes** (default), overridable via `DELIMIT_PHOENIX_FAIL_TTL_MS` (defensive parse: garbage / non-positive / empty → default). After expiry the model re-enters the chain and the **existing per-launch probe re-verifies health** before any session handoff.
- Within the TTL window behavior is byte-identical to the old Set semantics.

## LED-3433 — deterministic quota probe
- Verdict is keyed off **child exit code + stderr signatures only**. The free-form stdout reply is **never consulted**: exit 0 = healthy, even if the reply discusses "quota"/"rate limits" (the prior false-positive that quota-killed a healthy model).
- Nonzero exit: stderr matched against quota-cap, transient-429/503, and auth-error signatures. Transient keeps the existing back-off + single re-probe then proceeds; unknown errors log `probe error` and fail over to the next chain model exactly as before (fail-open preserved).
- **Codex is now probed** on the launch path (was trusted blind); probed set = claude, codex, gemini, gemini_consumer, antigravity.
- Same 12s timeout pattern; timeout/SIGTERM/143 still = healthy-but-slow.

## Behavior before/after
| Scenario | Before | After |
|---|---|---|
| Model fails over, quota resets 5h later | Excluded for entire process lifetime; session stuck on fallback | Eligible again after TTL (30 min default); probe re-verifies before handoff |
| `DELIMIT_PHOENIX_FAIL_TTL_MS=garbage` | n/a | Falls back to 30 min default |
| Probe exit 0, reply text mentions "usage limit"/"quota" | False-positive → marked quota-dead, failover | Healthy (stdout never consulted) |
| Probe nonzero exit + quota signature on stderr | Failover (if words matched combined output) | Failover (stderr-only, deterministic) |
| Probe nonzero exit, quota words on stdout only | Could be blamed on quota | `probe error` failover — never blamed on quota |
| Codex launch | Never probed (trusted blind) | Probed like claude/gemini-family |
| Timeout / transient 429 / non-quota error | slow=proceed / retry-then-proceed / fail-open next model | Unchanged |

## Customer protection (never-break-installs)
- `chat-repl.js` ships in the npm bundle to installed users. This change is **additive only**: no public method renames/removals, no CLI command or MCP tool surface changes, no storage-format changes. New exports (`FailedModelRegistry`, `resolvePhoenixFailTtlMs`, `DEFAULT_PHOENIX_FAIL_TTL_MS`) are additions.
- `delimit doctor` is **not required for this PR** (no publish); it remains the mandatory pre-publish step before any npm release that bundles this change.

## Tests
New hermetic suite `tests/chat-repl-phoenix-ttl-probe.test.js` (node:test, fixture-injected modelsConfig, mocked `_runProbe` spawn layer, injected clock — no live CLIs), following `tests/chat-repl-model-flag.test.js` conventions:
1. Failed model excluded within TTL, included again after expiry (+ re-failure restarts the window)
2. Env override respected; garbage values fall back to default
3. Exit 0 + stdout containing "limit"/"quota" ⇒ HEALTHY (false-positive regression, asserted explicitly)
4. Nonzero exit + stderr quota signature ⇒ failover
5. Codex on the probed launch path + probe hook invoked for codex
6. Plus: stdout-only quota words never classified quota-dead; timeout classes stay slow-healthy; transient retries once then proceeds

Full suite: `npm test` → **324 tests, 324 pass, 0 fail** (two consecutive clean runs). `node -c` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
