### PR TITLE
chore(bundle): classify ai/schemas stub INTERNAL (unblocks 4.16.1)

### DIFF
--- a/bundle-internal-exclude.txt
+++ b/bundle-internal-exclude.txt
@@ -83,6 +83,7 @@ gateway/ai/report_backlog.py
 gateway/ai/reports_distribution.py
 gateway/ai/reports_distribution_drainer.py
 gateway/ai/route_daemon.py
+gateway/ai/schemas/__init__.py
 gateway/ai/screen_record.py
 gateway/ai/seal/A1_BUNDLE.md
 gateway/ai/seal/producer.py


### PR DESCRIPTION
Sync-verifier catch during the founder-authorized 4.16.1 release: ai/schemas/__init__.py (empty stub, internal-only importers) was unclassified. One line. Merge basis: founder release authorization (panel below quorum, LED-1915).

🤖 Generated with [Claude Code](https://claude.com/claude-code)