### PR TITLE
fix(ci): anti-drift assert excludes generated checksums.sha256 (unblocks 4.16.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,11 +70,14 @@ jobs:
       - name: Assert committed bundle is in sync with gateway
         working-directory: npm-delimit
         run: |
-          # Ignore the transient license_core.py (kept for the .so compile) and
-          # any generated .so — those are expected to differ from HEAD.
+          # Ignore the transient license_core.py (kept for the .so compile),
+          # any generated .so, and checksums.sha256 (a manifest OVER those .so —
+          # CI compiles fresh .so [LED-1259], so its hashes differ from HEAD's;
+          # it is regenerated to match the actual shipped .so at pack time).
           DIRTY="$(git status --porcelain -- gateway/ \
             | grep -v 'gateway/ai/license_core.py' \
-            | grep -v 'gateway/ai/license_core.cpython' || true)"
+            | grep -v 'gateway/ai/license_core.cpython' \
+            | grep -v 'gateway/ai/checksums.sha256' || true)"
           if [ -n "$DIRTY" ]; then
             echo "::error::Committed bundle is STALE vs delimit-gateway. Run 'npm run sync-gateway', review, and COMMIT the bundle before tagging a release."
             echo "$DIRTY"


### PR DESCRIPTION
4.16.1 publish failed twice on 'M gateway/ai/checksums.sha256' — a manifest over the CI-compiled .so (fresh hashes each build), same generated-artifact class as the excluded license_core.py/.so, regenerated to match shipped .so at pack time. Source bundle verified genuinely in sync at v4.16.1. Merge basis: founder 4.16.1 release authorization (operational panel below quorum, LED-1915 hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)