### PR TITLE
fix: repoint dead Marketplace slug in shipped CLAUDE.md onboarding template

### DIFF
--- a/lib/delimit-template.js
+++ b/lib/delimit-template.js
@@ -99,7 +99,7 @@ For user-global overrides (rules that apply to every project and every Claude Co
 ## Links
 - Docs: https://delimit.ai/docs
 - GitHub: https://github.com/delimit-ai/delimit-mcp-server
-- Action: https://github.com/marketplace/actions/delimit-api-governance
+- Action: https://github.com/marketplace/actions/delimit-merge-gate-for-ai-written-code
 <!-- delimit:end -->`;
 }
 


### PR DESCRIPTION
## What
`lib/delimit-template.js` is the onboarding template `delimit setup` writes into **every user repo's CLAUDE.md**. Its Links section pointed at `https://github.com/marketplace/actions/delimit-api-governance` (now **404**). Repointed to the live listing `delimit-merge-gate-for-ai-written-code` (200).

The README was already fixed in #171 — the shipped template was missed in that pass, so newly-onboarded users still get the dead link written into their repo.

## Scope
- Only `lib/delimit-template.js` (the user-shipped template).
- `gateway/` synced copies intentionally **untouched** — those are fixed upstream in the gateway repo and re-synced on release (touching them here creates drift).

## Verify
Template/setup suite `tests/setup-no-clobber.test.js` → 15/15 pass. Pre-push hook reports 51 pre-existing failures on `main` (hardcoded-path tests under `gateway/ai/`), unrelated to this one-line doc change.

Drafts-only: no merge/publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)