### PR TITLE
fix(chat): codex --model TTY probe false-negative

### DIFF
--- a/lib/chat-repl.js
+++ b/lib/chat-repl.js
@@ -343,6 +343,13 @@ class DelimitChatREPL {
         }
         if (TRANSIENT_RATE_LIMIT.test(stderr)) return { verdict: 'transient' };
         if (AUTH_ERROR.test(stderr)) return { verdict: 'auth_error' };
+        // A CLI that refuses the NON-INTERACTIVE probe because it wants a TTY
+        // (e.g. codex: "Error: stdin is not a terminal"). This proves the model
+        // LAUNCHED and is reachable — it is NOT a quota/auth failure — and the
+        // real interactive session (stdio:'inherit', with a real TTY) is
+        // unaffected. Proceed rather than falsely failing over `--model codex`.
+        const NONINTERACTIVE_TTY = /not a (?:tty|terminal)|stdin is not a terminal|requires? (?:a )?(?:tty|terminal)|raw mode|interactive terminal/;
+        if (NONINTERACTIVE_TTY.test(stderr)) return { verdict: 'noninteractive' };
         if (r.error || (r.status !== null && r.status !== 0)) return { verdict: 'probe_error' };
         return { verdict: 'healthy' };
     }
@@ -373,6 +380,13 @@ class DelimitChatREPL {
                 return true;
             case 'healthy':
                 console.log(chalk.green('verified'));
+                return true;
+            case 'noninteractive':
+                // The probe can't run this CLI non-interactively (it wants a
+                // TTY, e.g. codex), but that error proves it LAUNCHED and is
+                // reachable — the real interactive session has a TTY. Proceed;
+                // do NOT fall over or blame quota.
+                console.log(chalk.green('reachable (interactive-only CLI) — proceeding'));
                 return true;
             case 'transient':
                 // Still transient after the retry — the plan is NOT exhausted,

--- a/tests/chat-repl-phoenix-ttl-probe.test.js
+++ b/tests/chat-repl-phoenix-ttl-probe.test.js
@@ -149,6 +149,27 @@ describe('LED-3433 deterministic quota probe', () => {
         assert.strictEqual(c.verdict, 'probe_error'); // fails over, but not blamed on quota
     });
 
+    it('non-interactive TTY error (codex "stdin is not a terminal") is reachable, NOT a probe failure', () => {
+        const r = replWith({});
+        // Real codex probe output: it launches then refuses non-interactive stdin.
+        assert.strictEqual(
+            r.classifyProbeResult(probeResult({ status: 1, stderr: 'Error: stdin is not a terminal' })).verdict,
+            'noninteractive',
+        );
+        assert.strictEqual(
+            r.classifyProbeResult(probeResult({ status: 1, stderr: 'raw mode is not supported: not a tty' })).verdict,
+            'noninteractive',
+        );
+        // And probeModelHealth PROCEEDS (returns true) rather than failing over.
+        assert.strictEqual(
+            silence(() => r.probeModelHealthFromResult
+                ? r.probeModelHealthFromResult({ status: 1, stderr: 'stdin is not a terminal' })
+                : (r._runProbe = () => probeResult({ status: 1, stderr: 'stdin is not a terminal' }),
+                   r.probeModelHealth({ id: 'codex' }, '/fake/shim'))),
+            true,
+        );
+    });
+
     it('timeout (ETIMEDOUT / SIGTERM / 143) stays healthy-but-slow', () => {
         const r = replWith({});
         assert.strictEqual(r.classifyProbeResult(probeResult({ status: 143 })).verdict, 'slow');


### PR DESCRIPTION
'delimit chat --model codex' failed with 'Probing codex quota... failed (probe error)'. Root cause: the pre-launch probe runs the shim non-interactively (-p space); codex refuses with 'Error: stdin is not a terminal' (nonzero exit) → classified probe_error → failover — even though it proves codex launched + is reachable (the real interactive session has a TTY). Fix: classify TTY/'not a terminal' as 'noninteractive' → proceed. Regression test added. Hot-patched live on the founder's box; this ships it to all users on next publish.