### PR TITLE
fix(bundle): classify firewall files internal-exclude (unblocks 4.16.2)

### DIFF
--- a/bundle-internal-exclude.txt
+++ b/bundle-internal-exclude.txt
@@ -164,3 +164,5 @@ gateway/ai/workers/outreach_drafter.py
 gateway/ai/workers/pr_drafter.py
 gateway/ai/x_ranker.py
 gateway/core/diff_engine_v2.py.bak
+gateway/ai/outreach_identity_firewall.py
+gateway/ai/fs_sector_denylist.txt


### PR DESCRIPTION
The LED-1919 firewall (#299) added gateway/ai/outreach_identity_firewall.py + gateway/ai/fs_sector_denylist.txt without bundle classification → publish.yml classification guard fail-closed on v4.16.2. Both are internal governance infra (contain founder-linkage deny-patterns) → INTERNAL-EXCLUDE (never ship to public npm). Verified: classification guard passes locally against gateway source. Unblocks the 4.16.2 publish.