### PR TITLE
fix(hooks): auto session-end capture — install SessionEnd hook in nested shape

### DIFF
--- a/lib/cross-model-hooks.js
+++ b/lib/cross-model-hooks.js
@@ -1078,6 +1078,269 @@ echo ""
         }
     }
 
+    // --- SessionEnd hook: deterministic capture floor on real session exit ---
+    //
+    // Bug this fixes: the Stop event fires when the assistant FINISHES A TURN,
+    // not when the user actually leaves. On a real exit (/exit, window close,
+    // SIGHUP) Claude Code fires SessionEnd — and we were never installing a
+    // SessionEnd hook (or, in older installs, one written in the FLAT shape that
+    // Claude Code silently ignores). Result: on exit nothing captured a handoff
+    // and the user had to manually prompt delimit_soul_capture.
+    //
+    // CRITICAL SHAPE CONTRACT: Claude Code only executes hooks in the NESTED
+    // shape — { matcher, hooks: [{ type, command, timeout }] }. A FLAT entry
+    // ({ type, command, matcher } at the top level) is parsed but never run.
+    // We ALWAYS write the nested shape here (same as SessionStart / Stop) so the
+    // hook actually fires for every installed user.
+    //
+    // Gated on session_start like the Stop hook (session lifecycle). The
+    // deployed delimit-session-end script does a DETERMINISTIC, time-boxed
+    // (<10s), NO-LLM capture: a session soul FLOOR (git state + ledger context
+    // + transcript tail from the SessionEnd event's transcript_path), stamped to
+    // .last_capture so the next session's delimit_revive finds a clean
+    // end-of-session handoff. A rich LLM soul still requires the model; this
+    // floor is the guaranteed automatic baseline. Best-effort, never blocks exit.
+    if (hookConfig.session_start) {
+        if (!config.hooks.SessionEnd) {
+            config.hooks.SessionEnd = [];
+        }
+        const home = getHome();
+        const hooksDir = path.join(home, '.claude', 'hooks');
+        fs.mkdirSync(hooksDir, { recursive: true });
+        const sessionEndScript = path.join(hooksDir, 'delimit-session-end');
+        const delimitHome = path.join(home, '.delimit');
+        const sessionEndContent = '#!/bin/bash\n' + `
+# Delimit SessionEnd — the guaranteed > in </> on real session exit.
+#
+# Claude Code fires SessionEnd on /exit, logout, window close, or clear, and
+# passes the event as JSON on stdin (session_id, transcript_path, reason). The
+# Stop hook only fires at end-of-TURN, so it can miss a hard exit; SessionEnd is
+# the safety net that guarantees an end-of-session floor handoff exists.
+#
+# This is a DETERMINISTIC, NO-LLM, time-boxed (<10s) capture:
+#   * git state (branch + porcelain changes + recent commits)
+#   * cheap ledger context (newest operations.jsonl summaries)
+#   * transcript tail (last assistant text + tool names — NO model call)
+# It writes a session soul FLOOR into ~/.delimit/sessions and stamps
+# .last_capture so the next session's delimit_revive sees a clean exit.
+# A rich LLM soul still needs the model (delimit_soul_capture); this floor is
+# the automatic baseline. Best-effort — ALWAYS exits 0, never blocks exit.
+
+DELIMIT_HOME="\${DELIMIT_HOME:-${delimitHome}}"
+
+# Capture stdin (SessionEnd event JSON) so the python floor can read transcript_path.
+SESSIONEND_EVENT_JSON="$(cat 2>/dev/null || true)"
+
+# Save session timestamp (back-compat, mirrors the Stop hook).
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$DELIMIT_HOME/.last_session_end" 2>/dev/null || true
+
+DELIMIT_HOME="$DELIMIT_HOME" SESSIONEND_EVENT_JSON="$SESSIONEND_EVENT_JSON" \\
+  timeout 8 python3 - <<'PYEOF' 2>/dev/null || true
+import json, os, sys, time, subprocess
+from pathlib import Path
+
+HOME = Path(os.environ.get("DELIMIT_HOME", str(Path.home() / ".delimit")))
+FRESH = 5 * 60
+stamp_path = HOME / ".last_capture"
+
+# Freshness gate: a fresh MODEL capture (a rich soul the user explicitly made)
+# wins — never clobber it with a floor. A prior deterministic floor does NOT
+# block us: SessionEnd should record the true end-of-session state.
+try:
+    stamp = json.loads(stamp_path.read_text())
+    if stamp.get("source") == "model" and (time.time() - float(stamp.get("ts", 0))) <= FRESH:
+        sys.exit(0)
+except Exception:
+    pass
+
+# Parse the SessionEnd event JSON for the transcript path.
+transcript_path = ""
+try:
+    ev = json.loads(os.environ.get("SESSIONEND_EVENT_JSON", "") or "{}")
+    transcript_path = ev.get("transcript_path", "") or ""
+except Exception:
+    pass
+
+def run_git(args):
+    try:
+        r = subprocess.run(["git"] + args, capture_output=True, text=True, timeout=4)
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except Exception:
+        return ""
+
+branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"])
+status = run_git(["status", "--porcelain"])
+changed = [l[3:].strip() for l in status.splitlines() if l.strip()][:50] if status else []
+recent_commits = run_git(["log", "-3", "--oneline"]).splitlines() if branch else []
+
+# Cheap ledger context: newest few operations.jsonl summaries.
+ledger_items = []
+try:
+    ops = HOME / "ledger" / "operations.jsonl"
+    if ops.exists():
+        lines = [l for l in ops.read_text(errors="replace").splitlines() if l.strip()]
+        for raw in lines[-40:]:
+            try:
+                o = json.loads(raw)
+            except Exception:
+                continue
+            if o.get("type") == "update":
+                continue
+            t = o.get("title") or o.get("summary") or ""
+            if t:
+                ledger_items.append(t[:120])
+        ledger_items = ledger_items[-5:]
+except Exception:
+    pass
+
+# Transcript tail: last assistant text + tool-call names (no LLM). Robust to
+# thinking-tails — prefer the last text block, fall back to the last thinking
+# block ("[thinking] ") so the floor is never empty; widen (capped) to recover
+# a text block pushed out of the immediate tail. Reads only the trailing ~64KB.
+final_text, final_thinking, tool_calls, turns = "", "", [], 0
+def _rc(o):
+    m = o.get("message") if isinstance(o, dict) else None
+    if isinstance(m, dict):
+        return (m.get("role", "") or (o.get("type", "") if isinstance(o, dict) else "")), m.get("content")
+    return (o.get("type", "") if isinstance(o, dict) else ""), (o.get("content") if isinstance(o, dict) else None)
+def _ex(content, sink):
+    tx, th = [], []
+    if isinstance(content, list):
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            bt = b.get("type")
+            if bt == "tool_use" and b.get("name") and sink is not None:
+                sink.append(str(b["name"]))
+            elif bt == "text" and b.get("text"):
+                tx.append(str(b["text"]))
+            elif bt == "thinking" and b.get("thinking"):
+                th.append(str(b["thinking"]))
+    elif isinstance(content, str):
+        tx.append(content)
+    return "\\n".join(tx).strip(), "\\n".join(th).strip()
+def _tail_text(path):
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            start = max(0, size - 65536)
+            fh.seek(start)
+            chunk = fh.read()
+        text = chunk.decode("utf-8", errors="replace")
+        if start > 0:
+            nl = text.find("\\n")
+            text = text[nl + 1:] if nl != -1 else ""
+        return text
+    except Exception:
+        return Path(path).read_text(errors="replace")
+try:
+    if transcript_path and Path(transcript_path).exists():
+        tl = [l for l in _tail_text(transcript_path).splitlines() if l.strip()]
+        tail = tl[-10:]
+        turns = len(tail)
+        for raw in tail:
+            try:
+                obj = json.loads(raw)
+            except Exception:
+                continue
+            role, content = _rc(obj)
+            tx, th = _ex(content, tool_calls)
+            if role == "assistant":
+                if tx:
+                    final_text = tx
+                if th:
+                    final_thinking = th
+        if not final_text and len(tl) > len(tail):
+            for raw in tl[-40:]:
+                try:
+                    obj = json.loads(raw)
+                except Exception:
+                    continue
+                role, content = _rc(obj)
+                if role != "assistant":
+                    continue
+                tx, th = _ex(content, None)
+                if tx:
+                    final_text = tx
+                if th:
+                    final_thinking = th
+        if not final_text and final_thinking:
+            final_text = "[thinking] " + final_thinking
+except Exception:
+    pass
+
+# Write the floor handoff into the sessions dir (same shape as session_handoff).
+sessions = HOME / "sessions"
+sessions.mkdir(parents=True, exist_ok=True)
+sid = "session_" + time.strftime("%Y%m%d_%H%M%S")
+summary = ("[deterministic floor / session-end] " + (final_text or "(no final assistant text)"))[:2000]
+key_decisions = []
+if tool_calls:
+    key_decisions.append("Last tools: " + ", ".join(tool_calls[-10:]))
+if ledger_items:
+    key_decisions.append("Open ledger: " + " | ".join(ledger_items))
+if recent_commits:
+    key_decisions.append("Recent commits: " + " | ".join(recent_commits))
+handoff = {
+    "id": sid,
+    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "venture": "all",
+    "summary": summary,
+    "items_completed": [],
+    "items_added": [],
+    "key_decisions": key_decisions,
+    "blockers": [],
+    "files_changed": changed,
+    "source": "deterministic",
+    "quality": "floor",
+    "git_branch": branch,
+    "trigger": "session-end",
+}
+try:
+    (sessions / (sid + ".json")).write_text(json.dumps(handoff, indent=2))
+except Exception:
+    pass
+
+# Stamp .last_capture so the next revive sees a clean exit.
+try:
+    stamp_path.parent.mkdir(parents=True, exist_ok=True)
+    stamp_path.write_text(json.dumps({
+        "ts": time.time(),
+        "iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "session_id": sid,
+        "source": "deterministic",
+        "quality": "floor",
+        "trigger": "session-end",
+    }))
+except Exception:
+    pass
+PYEOF
+exit 0
+`;
+        fs.writeFileSync(sessionEndScript, sessionEndContent);
+        fs.chmodSync(sessionEndScript, '755');
+
+        // Idempotent + no-clobber: only add our nested-shape group if no delimit
+        // SessionEnd hook already exists. User-owned SessionEnd hooks (any command
+        // without 'delimit') are left untouched — we merge, never replace.
+        const existingSessionEnd = config.hooks.SessionEnd.find(group => {
+            const cmds = (group.hooks || []).map(h => h.command || '');
+            return cmds.some(c => c.includes('delimit'));
+        });
+        if (!existingSessionEnd) {
+            config.hooks.SessionEnd.push({
+                matcher: '',
+                hooks: [{
+                    type: 'command',
+                    command: sessionEndScript,
+                    timeout: 10,
+                }],
+            });
+            changes.push('SessionEnd');
+        }
+    }
+
     // --- PostToolUse: STR-2202 subagent flight-recorder ---
     // A PostToolUse hook matched to the subagent-spawn tool (Claude Code names
     // it "Task"; some harnesses "Agent") auto-records the dispatch AND its
@@ -1517,7 +1780,7 @@ function removeClaudeHooks() {
 
         let changed = false;
 
-        for (const event of ['SessionStart', 'PreToolUse', 'PostToolUse', 'Stop']) {
+        for (const event of ['SessionStart', 'PreToolUse', 'PostToolUse', 'Stop', 'SessionEnd']) {
             if (Array.isArray(config.hooks[event])) {
                 const before = config.hooks[event].length;
                 config.hooks[event] = config.hooks[event].filter(h => {

--- a/tests/cross-model-hooks.test.js
+++ b/tests/cross-model-hooks.test.js
@@ -1037,6 +1037,144 @@ describe('STR-2202 subagent flight-recorder (PostToolUse)', () => {
 });
 
 // -----------------------------------------------------------------------
+// SessionEnd hook — deterministic capture floor on real session exit
+// -----------------------------------------------------------------------
+
+describe('SessionEnd hook install', () => {
+    beforeEach(() => { setupTmpHome(); });
+    afterEach(() => { teardownTmpHome(); });
+
+    it('installs a SessionEnd hook in the NESTED shape pointing at delimit-session-end', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        const changes = crossModelHooks.installClaudeHooks(tool, { session_start: true, conditional_hooks: false });
+
+        assert.ok(changes.includes('SessionEnd'), 'SessionEnd change should be reported');
+
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        assert.ok(Array.isArray(config.hooks.SessionEnd), 'SessionEnd should be an array');
+        assert.strictEqual(config.hooks.SessionEnd.length, 1, 'exactly one SessionEnd group');
+
+        const group = config.hooks.SessionEnd[0];
+        // NESTED shape: { matcher, hooks: [{ type, command, timeout }] }
+        assert.strictEqual(group.matcher, '', 'matcher present (nested shape)');
+        assert.ok(Array.isArray(group.hooks), 'nested hooks[] array present');
+        assert.strictEqual(group.hooks[0].type, 'command');
+        assert.ok(group.hooks[0].command.includes('delimit-session-end'), 'points at delimit-session-end script');
+        assert.strictEqual(group.hooks[0].timeout, 10, 'time-boxed under 10s');
+
+        // The deployed script exists and is executable.
+        const scriptPath = path.join(claudeDir, 'hooks', 'delimit-session-end');
+        assert.ok(fs.existsSync(scriptPath), 'delimit-session-end script deployed');
+        assert.ok((fs.statSync(scriptPath).mode & 0o111) !== 0, 'script is executable');
+    });
+
+    it('NEVER writes a FLAT-shape SessionEnd entry (Claude Code silently ignores flat)', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        crossModelHooks.installClaudeHooks(tool, { session_start: true, conditional_hooks: false });
+
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        for (const group of config.hooks.SessionEnd) {
+            // A flat entry carries command/type at the top level and no hooks[].
+            assert.strictEqual(group.command, undefined, 'no top-level command (would be flat)');
+            assert.strictEqual(group.type, undefined, 'no top-level type (would be flat)');
+            assert.ok(Array.isArray(group.hooks), 'every group uses nested hooks[]');
+        }
+    });
+
+    it('the deployed script does a deterministic, no-LLM floor capture (git + ledger + transcript tail)', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        crossModelHooks.installClaudeHooks(tool, { session_start: true });
+
+        const s = fs.readFileSync(path.join(claudeDir, 'hooks', 'delimit-session-end'), 'utf-8');
+        // Reads the SessionEnd event JSON from stdin for transcript_path.
+        assert.ok(s.includes('SESSIONEND_EVENT_JSON'), 'reads the SessionEnd event JSON');
+        assert.ok(s.includes('transcript_path'), 'reads transcript_path');
+        // Deterministic floor: git state + ledger + transcript tail, NO model call.
+        assert.ok(s.includes('rev-parse') && s.includes('status'), 'captures git state');
+        assert.ok(s.includes('operations.jsonl'), 'captures cheap ledger context');
+        assert.ok(s.includes('"source": "deterministic"'), 'floor is deterministic (no LLM)');
+        assert.ok(s.includes('.last_capture'), 'stamps .last_capture for next revive');
+        // Never-block contract: time-boxed + always exits 0.
+        assert.ok(s.includes("timeout 8 python3"), 'time-boxed (<10s)');
+        assert.ok(/exit 0\s*$/.test(s.trim()), 'always exits 0 (never blocks exit)');
+    });
+
+    it('is idempotent — installing twice yields exactly one SessionEnd group', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        crossModelHooks.installClaudeHooks(tool, { session_start: true, conditional_hooks: false });
+        const changes2 = crossModelHooks.installClaudeHooks(tool, { session_start: true, conditional_hooks: false });
+
+        assert.ok(!changes2.includes('SessionEnd'), 'second install reports no SessionEnd change');
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        const delimitGroups = config.hooks.SessionEnd.filter(
+            g => (g.hooks || []).some(hh => (hh.command || '').includes('delimit'))
+        );
+        assert.strictEqual(delimitGroups.length, 1, 'exactly one delimit SessionEnd group');
+    });
+
+    it('no-clobber — preserves a pre-existing user SessionEnd hook', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        // User already has their own SessionEnd hook (unrelated to delimit).
+        const userConfig = {
+            hooks: {
+                SessionEnd: [
+                    { matcher: '', hooks: [{ type: 'command', command: '/home/user/.scripts/my-cleanup.sh' }] },
+                ],
+            },
+        };
+        fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify(userConfig));
+
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+        crossModelHooks.installClaudeHooks(tool, { session_start: true, conditional_hooks: false });
+
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        const commands = config.hooks.SessionEnd.flatMap(g => (g.hooks || []).map(h => h.command || ''));
+        assert.ok(commands.some(c => c === '/home/user/.scripts/my-cleanup.sh'), 'user SessionEnd hook MUST be preserved');
+        assert.ok(commands.some(c => c.includes('delimit-session-end')), 'delimit SessionEnd hook added alongside');
+        assert.strictEqual(config.hooks.SessionEnd.length, 2, 'user hook + delimit hook = 2 groups');
+    });
+
+    it('is not installed when session_start is false (lifecycle-gated)', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        const changes = crossModelHooks.installClaudeHooks(tool, { session_start: false, conditional_hooks: false });
+        assert.ok(!changes.includes('SessionEnd'), 'not installed without session lifecycle');
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        assert.ok(!config.hooks.SessionEnd, 'no SessionEnd entry');
+    });
+
+    it('is stripped by removeClaudeHooks (reversible)', () => {
+        const claudeDir = path.join(tmpDir, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        const tool = { id: 'claude', name: 'Claude Code', configPath: path.join(claudeDir, 'settings.json') };
+
+        crossModelHooks.installClaudeHooks(tool, { session_start: true });
+        crossModelHooks.removeClaudeHooks();
+
+        const config = JSON.parse(fs.readFileSync(tool.configPath, 'utf-8'));
+        const remaining = (config.hooks && config.hooks.SessionEnd || []).filter(
+            g => (g.hooks || []).some(h => (h.command || '').includes('delimit'))
+        );
+        assert.strictEqual(remaining.length, 0, 'delimit SessionEnd removed on uninstall');
+    });
+});
+
+// -----------------------------------------------------------------------
 // LED-234: Helper function tests
 // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The Claude Code hook installer (`lib/cross-model-hooks.js`) wired `SessionStart`, `Stop`, and `PreToolUse`/`PostToolUse` hooks into `~/.claude/settings.json`, but **never installed a `SessionEnd` hook**. The `Stop` event fires at *end-of-turn*, not on real exit — so on `/exit`, logout, or window close, nothing captured a session handoff and users had to manually prompt `delimit_soul_capture`. (Older/hand-edited installs carrying a **flat-shape** `SessionEnd` are silently ignored by Claude Code, which only executes the **nested** shape.)

## Fix

- **`installClaudeHooks`** now installs a `SessionEnd` hook in the correct **nested** shape — `{ matcher: "", hooks: [{ type: "command", command: "<script>", timeout: 10 }] }` — pointing at a deployed `~/.claude/hooks/delimit-session-end` script. Idempotent (re-run is a no-op), additive merge (never clobbers a user's own `SessionEnd`/other hooks), gated on `session_start` like the `Stop` hook.
- **`delimit-session-end`** does a **deterministic, no-LLM, time-boxed (<10s)** capture: git state + cheap ledger context + transcript tail (from the SessionEnd event's `transcript_path` on stdin). It writes a session soul **FLOOR** into `~/.delimit/sessions` and stamps `.last_capture`, so the next session's `delimit_revive` finds a clean end-of-session handoff. Best-effort, **always exits 0, never blocks exit**. A fresh **model** capture (rich soul) is not clobbered. A rich LLM soul still requires the model; this floor is the guaranteed automatic baseline.
- **`removeClaudeHooks`** now also strips `SessionEnd` (reversible uninstall).

Gemini / Antigravity / Codex have no equivalent session-end lifecycle hook in this installer (they are MCP/instructions-based) — **Claude Code is the primary target**; left unchanged.

## Customer-protection / no-clobber

Additive, idempotent merge only. Existing user hooks under `SessionEnd` and every other event are preserved. `tests/setup-no-clobber.test.js` stays green. No MCP tool signatures, CLI commands, or storage formats change.

## Tests (`tests/cross-model-hooks.test.js`, 7 new)

1. `SessionEnd` installed in the **nested** shape pointing at `delimit-session-end`
2. a **flat**-shape `SessionEnd` is **never** written
3. the deployed script does a deterministic, no-LLM floor (git + ledger + transcript tail, stamps `.last_capture`, `timeout 8`, `exit 0`)
4. **idempotent** (install twice → one group)
5. **no-clobber** (a pre-existing user `SessionEnd` hook is preserved alongside)
6. lifecycle-gated (not installed when `session_start:false`)
7. reversible (`removeClaudeHooks` strips it)

All 7 pass. Full local suite delta: baseline `315/261/51` → `322/268/51` — **+7 tests, +7 pass, 0 new failures** (the 51 pre-existing failures are CLI-spawn tests requiring the full gateway stack, absent locally; they fail identically on `main`).

## Deploy note

This ships to installed users **only on the next `npm publish`** (founder-gated). No publish in this PR. No merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)