### PR TITLE
fix(chat): reliable cross-agent continuity in delimit chat (LED-1962)

### DIFF
--- a/lib/chat-repl.js
+++ b/lib/chat-repl.js
@@ -142,10 +142,23 @@ class DelimitChatREPL {
         return activeModels;
     }
 
-    // Capture the current session's soul before Auto-Phoenix switches models,
-    // so the next agent can revive the context. Resolves the server path at
-    // runtime (bundled gateway, then the installed server) instead of a
-    // hardcoded dev path. Returns true only if capture actually succeeded.
+    // Capture the DYING session's real context before Auto-Phoenix switches
+    // models, so the next agent revives actual work — not a thin marker.
+    //
+    // LED-1962: this used to call capture_soul(active_task="Auto-Phoenix
+    // migration from X") with everything else empty. That wrote a THIN soul
+    // (no decisions / next-steps) that (a) became the newest soul and shadowed
+    // the real context, and (b) stamped .last_capture — which made the NEXT
+    // session's SessionStart reconcile_orphan skip salvaging the dying model's
+    // transcript. Both defeated the point of the capture.
+    //
+    // Fix: use reconcile_orphan (LED-1705/3711) — it salvages the dying model's
+    // transcript tail (cross-harness) into a rich floor soul, and its
+    // .last_capture guard means it never clobbers a fresh model-authored soul
+    // (returns "skipped/last_capture_present" — the rich soul already exists).
+    // Only when there is genuinely nothing to salvage do we fall back to the
+    // old thin capture, so we never lose the git-state floor. Returns true if
+    // anything was captured/left in place. Resolves the server path at runtime.
     captureSoulForMigration(fromModel) {
         const candidates = [
             path.join(__dirname, '..', 'gateway'),
@@ -155,13 +168,46 @@ class DelimitChatREPL {
             if (!fs.existsSync(path.join(base, 'ai', 'session_phoenix.py'))) continue;
             try {
                 const pyCmd = `import sys; sys.path.insert(0, ${JSON.stringify(base)}); `
-                    + `from ai.session_phoenix import capture_soul; `
-                    + `capture_soul(active_task=${JSON.stringify('Auto-Phoenix migration from ' + fromModel)})`;
+                    + `from ai.session_phoenix import reconcile_orphan, capture_soul\n`
+                    + `r = reconcile_orphan() or {}\n`
+                    + `status = r.get("status"); reason = r.get("reason", "")\n`
+                    + `# reconciled = rich salvage done; skipped+last_capture_present = a\n`
+                    + `# fresh rich soul already exists. Either way, do NOT write a thin\n`
+                    + `# marker. Only floor-capture when nothing is salvageable.\n`
+                    + `if not (status == "reconciled" or (status == "skipped" and reason == "last_capture_present")):\n`
+                    + `    capture_soul(active_task=${JSON.stringify('Auto-Phoenix migration from ' + fromModel)})\n`;
                 const r = spawnSync('python3', ['-c', pyCmd], { stdio: 'ignore' });
                 if (r.status === 0) return true;
             } catch (e) { /* try next candidate */ }
         }
         return false;
+    }
+
+    // LED-1962: Revive the CURRENT-PROJECT soul as a plain context string, for
+    // injecting into a launched model that has NO session-start injection hook
+    // (Codex). Claude Code revives via its SessionStart hook, so we never inject
+    // for claude (that would double the context). Current-project only —
+    // `delimit chat` switches models IN THE SAME cwd, so a cross-project global
+    // scan is unnecessary and would risk cross-venture bleed. Returns the
+    // formatted soul, or "" if none / unavailable. Fail-open, time-boxed.
+    reviveSoulForLaunch() {
+        const candidates = [
+            path.join(__dirname, '..', 'gateway'),
+            path.join(os.homedir(), '.delimit', 'server'),
+        ];
+        for (const base of candidates) {
+            if (!fs.existsSync(path.join(base, 'ai', 'session_phoenix.py'))) continue;
+            try {
+                const pyCmd = `import sys; sys.path.insert(0, ${JSON.stringify(base)}); `
+                    + `from ai.session_phoenix import get_latest_soul, _format_revival; `
+                    + `s = get_latest_soul(); `
+                    + `sys.stdout.write(_format_revival(s)) if s is not None else None`;
+                const r = spawnSync('python3', ['-c', pyCmd], { encoding: 'utf-8', timeout: 6000 });
+                if (r.status === 0 && r.stdout && r.stdout.trim()) return r.stdout.trim();
+                return '';
+            } catch (e) { /* try next candidate */ }
+        }
+        return '';
     }
 
     // LED-1710: validate cross-agent handoff invariants (committer identity,
@@ -502,6 +548,26 @@ class DelimitChatREPL {
                         if (concrete) modelName = concrete;
                     }
                     args.unshift('-m', modelName);
+                }
+            }
+
+            // LED-1962: Codex has NO session-start injection hook (unlike Claude
+            // Code, which auto-revives via ~/.claude/hooks/delimit). So a `delimit
+            // chat` migration TO codex would start blind — it only gets the
+            // strengthened instructions.md hint, not the actual context. Inject the
+            // revived current-project soul as codex's initial PROMPT so the switch
+            // resumes with the last task/decisions/next-steps. The codex shim does
+            // `exec codex "$@"`, so a positional arg reaches codex as [PROMPT].
+            // Claude is intentionally excluded (its hook already injects; doubling
+            // would just bloat context). Fail-open: no soul -> launch unchanged.
+            if (activeModel.id === 'codex') {
+                const soul = this.reviveSoulForLaunch();
+                if (soul) {
+                    args.push(
+                        '[Auto-revived session context — you just switched agents '
+                        + '(e.g. a quota limit). This is where the previous agent left '
+                        + 'off. Read it, then continue.]\n\n' + soul
+                    );
                 }
             }
 

--- a/scripts/test-with-config-guard.js
+++ b/scripts/test-with-config-guard.js
@@ -44,6 +44,7 @@ const TEST_FILES = [
     'tests/control-browser.test.js',
     'tests/bundle-parity-guard.test.js',
     'tests/chat-repl-prebrief.test.js',
+    'tests/chat-repl-continuity.test.js',
 ];
 
 const cfgPath = resolveSharedConfigPath();

--- a/tests/chat-repl-continuity.test.js
+++ b/tests/chat-repl-continuity.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// LED-1962: `delimit chat` cross-agent continuity.
+//
+// Two fixes, guarded here at the source + wiring level (the interactive launch
+// loop and the python-spawning helpers can't be unit-run in CI without a live
+// gateway + polluting ~/.delimit/souls, so we assert the load-bearing shape and
+// rely on the documented runtime verification for behavior):
+//   Fix 1  reviveSoulForLaunch injects the revived CURRENT-project soul into
+//          codex's launch prompt (codex has no session-start hook; claude is
+//          excluded because its SessionStart hook already injects).
+//   Fix 2  captureSoulForMigration salvages the dying session's REAL transcript
+//          via reconcile_orphan instead of writing a thin "migration from X"
+//          soul that both shadowed context and blocked the next reconcile.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { DelimitChatREPL } = require('../lib/chat-repl');
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'lib', 'chat-repl.js'), 'utf-8');
+
+describe('LED-1962 delimit chat cross-agent continuity', () => {
+    test('exposes the continuity helpers on the REPL', () => {
+        const repl = new DelimitChatREPL({});
+        assert.strictEqual(typeof repl.reviveSoulForLaunch, 'function',
+            'reviveSoulForLaunch is wired');
+        assert.strictEqual(typeof repl.captureSoulForMigration, 'function',
+            'captureSoulForMigration is wired');
+    });
+
+    // --- Fix 2: rich migration capture ---------------------------------------
+    test('captureSoulForMigration salvages via reconcile_orphan, not a thin marker', () => {
+        // The dying session's transcript is salvaged (rich) instead of writing a
+        // thin "Auto-Phoenix migration from X" soul.
+        assert.ok(/reconcile_orphan/.test(SRC),
+            'migration capture calls reconcile_orphan');
+        // The thin capture_soul(active_task="Auto-Phoenix migration…") is now only
+        // a FALLBACK (guarded by the "nothing salvageable" branch), never the
+        // default. Guard: it must be preceded by the reconcile decision.
+        const migrationIdx = SRC.indexOf('Auto-Phoenix migration from');
+        const reconcileIdx = SRC.indexOf('reconcile_orphan');
+        assert.ok(reconcileIdx !== -1 && reconcileIdx < migrationIdx,
+            'reconcile_orphan runs before the thin fallback');
+        // The fresh-capture guard: never clobber a soul the model already wrote.
+        assert.ok(/last_capture_present/.test(SRC),
+            'respects the .last_capture guard (no clobber of a fresh rich soul)');
+    });
+
+    // --- Fix 1: codex soul injection -----------------------------------------
+    test('injects the revived soul into codex launch, but NOT claude', () => {
+        // Codex has no injection hook -> chat injects the soul as its prompt.
+        assert.ok(/activeModel\.id === 'codex'/.test(SRC),
+            'codex launch is special-cased for soul injection');
+        assert.ok(/reviveSoulForLaunch\(\)/.test(SRC),
+            'the codex path revives a soul to inject');
+        assert.ok(/Auto-revived session context/.test(SRC),
+            'the injected prompt is clearly labeled as revived context');
+        // Claude must NOT be injected here (it revives via its SessionStart hook;
+        // double-injection would just bloat context). There is no
+        // `activeModel.id === 'claude'` soul-injection branch.
+        assert.ok(!/activeModel\.id === 'claude'[\s\S]{0,120}reviveSoulForLaunch/.test(SRC),
+            'claude is not double-injected');
+    });
+
+    test('reviveSoulForLaunch is CURRENT-project only (no cross-venture global scan)', () => {
+        // `delimit chat` switches models in the same cwd, so the revive is scoped
+        // to the current project (get_latest_soul with no arg = cwd). It must NOT
+        // pull find_most_recent_soul_across_projects, which would risk injecting a
+        // different venture's soul into this session.
+        const fnStart = SRC.indexOf('reviveSoulForLaunch()');
+        const fnBody = SRC.slice(fnStart, fnStart + 900);
+        assert.ok(/get_latest_soul\(\)/.test(fnBody),
+            'reviveSoulForLaunch uses the current-project soul');
+        assert.ok(!/find_most_recent_soul_across_projects/.test(fnBody),
+            'reviveSoulForLaunch does NOT do a cross-project global scan');
+    });
+});


### PR DESCRIPTION
## Context
Follows #182 (SessionStart auto-revive). `delimit chat` is the quota-aware multi-model REPL with Auto-Phoenix; on a quota switch it captures a soul and relies on the next model's session-start to revive it. Two gaps made that unreliable — both fixed here, both verified at runtime.

## Fix 1 — inject the revived soul into Codex on migration
Chat launches each model via `spawnSync(shim, args)` and delegated revival to the model's own session-start (*'{nextModel} will revive it on start'*). That works for **Claude** (its SessionStart hook auto-injects, #182) but **Codex has no injection hook** — a quota switch to Codex started blind (instruction-only). New `reviveSoulForLaunch()` emits the **current-project** soul (chat switches in-place → no cross-project global scan → no cross-venture bleed) and pushes it as codex's initial `[PROMPT]` (the codex shim does `exec codex "$@"`). **Claude is excluded** to avoid double-injecting over its hook.

## Fix 2 — capture the DYING session's real context, not a thin marker
`captureSoulForMigration` wrote `capture_soul(active_task='Auto-Phoenix migration from X')` with everything else empty. That thin soul **(a)** became the newest soul and **shadowed** the real work context, and **(b)** stamped `.last_capture`, which made the *next* session's `reconcile_orphan` **skip** salvaging the dying model's transcript. Now it calls **`reconcile_orphan`** (LED-1705/3711) to salvage the transcript tail into a rich floor soul, respecting the `.last_capture` guard so it **never clobbers** a fresh model-authored soul; falls back to the thin git-state floor only when nothing is salvageable.

## Verification
- `reviveSoulForLaunch` emits the formatted current-project soul (confirmed from a soul-bearing cwd; correctly empty from a soul-less one).
- `reconcile_orphan` returns `skipped/last_capture_present` and correctly does **not** write the thin marker when a fresh capture exists.
- Codex shim confirmed to `exec codex "$@"` (injected prompt reaches codex).
- Claude-via-chat: the SessionStart hook is launch-agnostic, so chat→claude auto-revives via #182 (mechanism verified; full interactive flow not scripted).

## Tests / safety
`tests/chat-repl-continuity.test.js` +4, **added to the config-guard runner list** so CI actually runs them. Full suite **340 pass / 0 fail**. Additive; no tool/command/format change. npm publish is a **separate** founder gate — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)