### PR TITLE
fix(chat): time-box migration spawn + reviveSoulForLaunch candidate fallthrough (LED-1964)

### DIFF
--- a/lib/chat-repl.js
+++ b/lib/chat-repl.js
@@ -176,7 +176,10 @@ class DelimitChatREPL {
                     + `# marker. Only floor-capture when nothing is salvageable.\n`
                     + `if not (status == "reconciled" or (status == "skipped" and reason == "last_capture_present")):\n`
                     + `    capture_soul(active_task=${JSON.stringify('Auto-Phoenix migration from ' + fromModel)})\n`;
-                const r = spawnSync('python3', ['-c', pyCmd], { stdio: 'ignore' });
+                // LED-1964: time-box the spawn so a hung python can't stall the
+                // Auto-Phoenix migration. On timeout r.status is null (not 0), so
+                // we fall through to the next candidate / return false (fail-open).
+                const r = spawnSync('python3', ['-c', pyCmd], { stdio: 'ignore', timeout: 6000 });
                 if (r.status === 0) return true;
             } catch (e) { /* try next candidate */ }
         }
@@ -204,7 +207,9 @@ class DelimitChatREPL {
                     + `sys.stdout.write(_format_revival(s)) if s is not None else None`;
                 const r = spawnSync('python3', ['-c', pyCmd], { encoding: 'utf-8', timeout: 6000 });
                 if (r.status === 0 && r.stdout && r.stdout.trim()) return r.stdout.trim();
-                return '';
+                // LED-1964: fall through to the next candidate (bundled gateway ->
+                // installed server) on a failed/empty first candidate, instead of
+                // returning "" prematurely; only give up after both are exhausted.
             } catch (e) { /* try next candidate */ }
         }
         return '';


### PR DESCRIPTION
Two non-blocking nits the PR #183 deliberation-as-review flagged (logged as LED-1964, merge condition):

1. **`captureSoulForMigration` spawn had no timeout** — a hung python could stall Auto-Phoenix migration. Added `timeout: 6000` (fail-open: on timeout `r.status` is null, so it falls through to the next candidate / returns false).
2. **`reviveSoulForLaunch` returned `''` after the first candidate failed/emptied** instead of trying the next (bundled gateway → installed server). Now falls through to the next candidate; only returns `''` after both are exhausted.

Neither affected the normal bundled-gateway path (why they were non-blocking). Additive, fail-open. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)