### PR TITLE
fix(LED-4078): classify gateway/ai/thinktank_pipeline.py as internal

### DIFF
--- a/bundle-internal-exclude.txt
+++ b/bundle-internal-exclude.txt
@@ -196,3 +196,4 @@ gateway/ai/mailbox_secret_resolver.py
 gateway/ai/mailbox_service.py
 gateway/ai/mailbox_service_daemon.py
 gateway/ai/mailbox_transport_receipt.py
+gateway/ai/thinktank_pipeline.py


### PR DESCRIPTION
One-line publish-gate fix. The gateway's LED-3916 build added the internal-only `thinktank_pipeline.py` backing module (npm-excluded on the gateway side). Without this matching entry, `check-bundle-classification.sh` fails on the new unclassified file at the next gateway→npm sync, breaking the publish. No publish, no behavior change (the npm `files` allowlist already excludes the module; shipped tools degrade to `not_available`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)